### PR TITLE
Wording.

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
           <ul>
             <li><strong>本站带宽资源有限，为了您和他人可以长久使用本站服务，请勿使用迅雷下载本站内容。</strong></li>
             <li><strong>若您需要通过本站建立镜像，请提前联系管理员。</strong> </li>
-            <li><strong>AOSP 镜像服务单 IP 并发数限制为 4, 因版权原因，我们无法提供 Android SDK 镜像, 有任何疑问, 请联系管理员。</strong> </li>
+            <li><strong>AOSP 镜像服务单 IP 并发数限制为 4。因版权原因，我们无法提供 Android SDK 镜像。</strong> </li>
           </ul>
           <br />
 


### PR DESCRIPTION
A comma is turned into a period to allow more breathing. A "contact admin"
sentence is removed since a variant of it (with clickable link to contact)
appears immediately after it.