### PR TITLE
Remove siglevel from archlinuxcn mirror config

### DIFF
--- a/_posts/help/1970-01-01-archlinuxcn.md
+++ b/_posts/help/1970-01-01-archlinuxcn.md
@@ -19,7 +19,6 @@ Arch Linux 中文社区仓库 是由 Arch Linux
 
 ```
 [archlinuxcn]
-SigLevel = Optional TrustedOnly
 Server = http://mirrors.tuna.tsinghua.edu.cn/archlinuxcn/$arch
 ```
 


### PR DESCRIPTION
> since all packages are signed, default value for SigLevel (Required
DatabaseOptional) is better. -- lilydjwg

see also: archlinuxcn/repo#218