### PR TITLE
add gpg checker

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,11 +1,13 @@
 FROM ruby:2.3
 
 RUN mkdir /data
+RUN mkdir /gpghome
 WORKDIR /data
 
-RUN apt-get update && apt-get -y install nodejs
+RUN apt-get update && apt-get -y install nodejs gnupg git
 
 COPY Gemfile /data/
+COPY build.sh /
 
 RUN gem install bundler
 RUN bundle install
@@ -15,4 +17,4 @@ RUN sed -i 's/@context ||= ExecJS.compile("var self = this; " + File.read(script
 
 ENV LANG en_US.UTF-8
 
-CMD ["jekyll", "build"]
+CMD ["/build.sh"]

--- a/_config.yml
+++ b/_config.yml
@@ -29,7 +29,7 @@ gems:
 
 babel_js_extensions: 'es6'
 
-exclude: [Gemfile, Gemfile.lock, README.md, gen_robot.sh, vendor, geninfo/, gen_robot.sh, gen_desc.py, Dockerfile*]
+exclude: [Gemfile, Gemfile.lock, README.md, gen_robot.sh, vendor, geninfo/, gen_robot.sh, gen_desc.py, Dockerfile*, build.sh]
 
 # Content Related
 new_mirrors:

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+keyserver=${KEYSERVER:-"hkp://sks.ustclug.org"}
+
+if [ -d .git/ ]; then
+  git cat-file commit HEAD  | sed '/^gpgsig/,/-----END PGP SIGNATURE-----$/ D' > /tmp/commit
+  git cat-file commit HEAD  | sed -n '/^gpgsig/,/-----END PGP SIGNATURE-----$/ P' | sed 's/^gpgsig//; s/^ //' > /tmp/sig
+
+  if [ -e /gpghome/trustdb.gpg ]; then
+    gpg --homedir=/gpghome --keyserver="$keyserver" --refresh-keys 
+    gpg_out=$(gpg --homedir=/gpghome --verify --status-fd 1 --trust-model direct /tmp/sig /tmp/commit)
+    gpg_status=$?
+    echo "$gpg_out" > /dev/stderr
+    if [ "$gpg_status" -ne 0 ]; then 
+      echo "gpg --verify exited with code $gpg_status" >/dev/stderr
+      exit 1
+    fi
+    if echo "$gpg_out" | grep -qs "^\[GNUPG:\] VALIDSIG" &&
+       echo "$gpg_out" | grep -qs "^\[GNUPG:\] TRUST_FULLY\$"; then
+      echo "Sig check succeed" > /dev/stderr
+    else
+      echo "Sig check failed" > /dev/stderr
+      exit 1
+    fi 
+    
+  else
+    echo "No trustdb found, skipping sig check" > /dev/stderr
+  fi
+
+else
+  echo "No git repo found, skipping sig check" > /dev/stderr
+fi
+
+exec jekyll build --future
+


### PR DESCRIPTION
添加 gpg 签名检查脚本，以便核对最新提交的 gpg 签名，若签名有效且可信，则部署。