### PR TITLE
Add debian stretch to gitlab-ce help

### DIFF
--- a/_posts/help/1970-01-01-gitlab-ce.md
+++ b/_posts/help/1970-01-01-gitlab-ce.md
@@ -24,6 +24,7 @@ curl https://packages.gitlab.com/gpg.key 2> /dev/null | sudo apt-key add - &>/de
 	<select class="form-control release-select" data-template="#apt-template" data-target="#apt-content">
 		<option data-os="debian" data-release="wheezy">Debian 7 (Wheezy)</option>
 		<option data-os="debian" data-release="jessie" selected>Debian 8 (Jessie)</option>
+		<option data-os="debian" data-release="stretch" selected>Debian 9 (Stretch)</option>
 		<option data-os="ubuntu" data-release="trusty">Ubuntu 14.04 LTS</option>
 		<option data-os="ubuntu" data-release="xenial">Ubuntu 16.04 LTS</option>
 </select>


### PR DESCRIPTION
GitLab has added support for Debian Stretch, and it's already in the mirror (I've been using it).
I've tested the page on my PC, hopefully everything works.

Thank you guys, great work!