### PR TITLE
调高main频道优先级顺序

### DIFF
--- a/_posts/help/1970-01-01-anaconda.md
+++ b/_posts/help/1970-01-01-anaconda.md
@@ -13,8 +13,8 @@ Anaconda 安装包可以到 <https://mirrors.tuna.tsinghua.edu.cn/anaconda/archi
 TUNA 还提供了 Anaconda 仓库的镜像，运行以下命令:
 
 ```
-conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/main/
 conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/free/
+conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/main/
 conda config --set show_channel_urls yes
 ```
 


### PR DESCRIPTION
先添加 free频道，后添加 main 频道，使main排在前面，调高优先级。
根据 [Anaconda 文档](https://docs.anaconda.com/anaconda/release-notes)，main 频道默认拥有 top priority. 

调整之前 `.condarc` 文件：

```
channels:
  - https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/free/
  - https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/main/
  - defaults
show_channel_urls: true
```

调整之后：
```
channels:
  - https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/main/
  - https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/free/
  - defaults
show_channel_urls: true
```
  