### PR TITLE
mark anaconda repo of peterjc123 legacy

### DIFF
--- a/_posts/help/1970-01-01-anaconda.md
+++ b/_posts/help/1970-01-01-anaconda.md
@@ -61,7 +61,7 @@ conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/
 ```
 conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/pytorch/
 
-# for win-64
+# for legacy win-64
 conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/peterjc123/
 ```
 


### PR DESCRIPTION
As win-64 has been released in official pytorch repo since 0.4.0.