### PR TITLE
help: docker-ce: Fix wrong rendering on centos/fedora distro switch

### DIFF
--- a/_posts/help/1970-01-01-docker-ce.md
+++ b/_posts/help/1970-01-01-docker-ce.md
@@ -27,7 +27,7 @@ sudo apt-get install apt-transport-https ca-certificates curl gnupg2 software-pr
 <form class="form-inline">
 <div class="form-group">
 	<label>根据你的发行版，下面的内容有所不同。你使用的发行版： </label>
-	<select class="form-control release-select" v-model="deb_release">
+	<select class="form-control" v-model="deb_release">
 	  <option value="debian" selected>Debian</option>
 	  <option value="ubuntu">Ubuntu</option>
 	</select>
@@ -95,18 +95,19 @@ sudo yum install -y yum-utils device-mapper-persistent-data lvm2
 <form class="form-inline">
 <div class="form-group">
 	<label>根据你的发行版下载repo文件: </label>
-	<select class="form-control release-select" data-template="#yum-template" data-target="#yum-content" v-model="release_name">
-	  <option value="centos" data-release="centos" selected>CentOS/RHEL</option>
-	  <option value="fedora" data-release="fedora">Fedora</option>
+	<select class="form-control" v-model="yum_release">
+	  <option value="centos" selected>CentOS/RHEL</option>
+	  <option value="fedora">Fedora</option>
 	</select>
 </div>
 </form>
 
+{% raw %}
 <p></p>
 <pre>
-<code id="yum-content">
-</code>
+<code id="yum-content">wget -O /etc/yum.repos.d/docker-ce.repo https://download.docker.com/linux/{{ yum_release }}/docker-ce.repo</code>
 </pre>
+{% endraw %}
 
 把软件仓库地址替换为 TUNA:
 
@@ -122,16 +123,12 @@ sudo yum install docker-ce
 ```
 
 {% raw %}
-<script id="yum-template" type="x-tmpl-markup">
-wget -O /etc/yum.repos.d/docker-ce.repo https://download.docker.com/linux/{{release_name}}/docker-ce.repo
-</script>
-
 <script>
 var vue = new Vue({
     el: "#help-content",
     data: {
         deb_release: 'debian',
-        release_name: 'centos'
+        yum_release: 'centos'
     },
     computed: {
 


### PR DESCRIPTION
Vue processes all {{ x }}. So /static/js/help.js:update_apt_file will
never get literal '{{ release_name }}', leading to wrong rendering.

Bug: https://groups.google.com/forum/#!topic/tuna-general/oFZ0v78hYPc
Reported-By: windforce17
Signed-off-by: Xiami <i@f2light.com>