### PR TITLE
简化Termux的使用帮助

### DIFF
--- a/_posts/help/1970-01-01-termux.md
+++ b/_posts/help/1970-01-01-termux.md
@@ -30,35 +30,8 @@ Termux 是运行在 Android 上的 terminal。不需要root，运行于内部存
 
 使用
 
-```
-apt edit-sources
-```
-
-如果提示
-
-```
-$ apt edit-sources E: Sub-process editor returned an error code (100)
+``` bash
+sed -i 's@https://termux.net@https://mirrors.tuna.tsinghua.edu.cn/termux@' $PREFIX/etc/apt/sources.list
+pkg up
 ```
 
-则需要设置一下`$EDITOR`:
-
-```
-export EDITOR=vi
-apt edit-sources
-```
-
-以 32位 ARM 平台为例，打开你常用的文本编辑器，替换成如下内容
-
-```
-# The termux repository mirror from TUNA:
-deb [arch=all,arm] https://mirrors.tuna.tsinghua.edu.cn/termux stable main
-```
-
-或通过 http 访问（不建议）：
-
-```
-# The termux repository mirror from TUNA:
-deb [arch=all,arm] http://mirrors.tuna.tsinghua.edu.cn/termux stable main
-```
-
-如果您用的是 64位 ARM 平台，请用 aarch64 替换 arm ；如果是 Intel 平台，则用 i686 / x86_64 分别表示 32位 和 64 位。


### PR DESCRIPTION
Termux已经不再需要原先繁琐的换源方式，直接使用sed替换即可