### PR TITLE
更新 Termux 官方源地址

### DIFF
--- a/_posts/help/1970-01-01-termux.md
+++ b/_posts/help/1970-01-01-termux.md
@@ -33,7 +33,7 @@ Termux 是运行在 Android 上的 terminal。不需要root，运行于内部存
 使用如下命令自动替换官方源为 TUNA 镜像源
 
 ``` bash
-sed -i 's@dl.bintray.com/termux/termux-packages-24@mirrors.tuna.tsinghua.edu.cn/termux@' $PREFIX/etc/apt/sources.list
+sed -i 's@^\(deb.*stable main\)$@#\1\ndeb https://mirrors.tuna.tsinghua.edu.cn/termux stable main@' $PREFIX/etc/apt/sources.list
 pkg up
 ```
 

--- a/_posts/help/1970-01-01-termux.md
+++ b/_posts/help/1970-01-01-termux.md
@@ -28,10 +28,22 @@ Termux 是运行在 Android 上的 terminal。不需要root，运行于内部存
 如何使用 Termux 镜像
 ------------------
 
-使用
+### 自动替换
+
+使用如下命令自动替换官方源为 TUNA 镜像源
 
 ``` bash
-sed -i 's@https://termux.net@https://mirrors.tuna.tsinghua.edu.cn/termux@' $PREFIX/etc/apt/sources.list
+sed -i 's@dl.bintray.com/termux/termux-packages-24@mirrors.tuna.tsinghua.edu.cn/termux@' $PREFIX/etc/apt/sources.list
 pkg up
 ```
 
+### 手动修改
+
+编辑 `$PREFIX/etc/apt/sources.list` 修改为如下内容
+
+```
+# The termux repository mirror from TUNA:
+deb https://mirrors.tuna.tsinghua.edu.cn/termux stable main
+```
+
+请使用内置或安装在 Termux 里的文本编辑器，例如 `vi` / `vim` / `nano` 等，**不要使用 RE 管理器等其他具有 ROOT 权限的外部 APP** 来修改 Termux 的文件


### PR DESCRIPTION
Termux 官方已将软件源迁移至 Bintray，软件源地址也发生了变化

See :
https://github.com/termux/termux-packages/commit/99134641d625f7d9d8735f299802857b31ea0a55
https://github.com/termux/termux-packages/commit/c7b1632e32804e1648ef51a3733afc755a75d153
https://github.com/termux/termux-packages/commit/f780fde2e7b0ac16ec21ac7ce8a41a4ef62267e5

