### PR TITLE
Update docs for stack v2.1.1 .

### DIFF
--- a/_posts/help/1970-01-01-hackage.md
+++ b/_posts/help/1970-01-01-hackage.md
@@ -4,9 +4,9 @@ layout: help
 mirrorid: hackage
 ---
 
-## hackage 镜像使用帮助
+# hackage 镜像使用帮助
 
-### 初次使用
+## 在`cabel`中初次使用
 
 先执行
 
@@ -53,7 +53,33 @@ remote-repo: mirrors.tuna.tsinghua.edu.cn:http://mirrors.tuna.tsinghua.edu.cn/ha
 
 再执行`cabal update`, 即可使用`cabal`安装包了。
 
-### 在 [`stack`](https://github.com/commercialhaskell/stack) 中使用
+## 在 [`stack`](https://github.com/commercialhaskell/stack) 中使用
+
+### stack > v2.1.1
+
+修改`~/.stack/config.yaml`, 加上:
+
+```yaml
+package-indices:
+  - download-prefix: http://mirrors.tuna.tsinghua.edu.cn/hackage
+    hackage-security:
+        keyids:
+        - 0a5c7ea47cd1b15f01f5f51a33adda7e655bc0f0b0615baa8e271f4c3351e21d
+        - 1ea9ba32c526d1cc91ab5e5bd364ec5e9e8cb67179a471872f6e26f0ae773d42
+        - 280b10153a522681163658cb49f632cde3f38d768b736ddbc901d99a1a772833
+        - 2a96b1889dc221c17296fcc2bb34b908ca9734376f0f361660200935916ef201
+        - 2c6c3627bd6c982990239487f1abd02e08a02e6cf16edb105a8012d444d870c3
+        - 51f0161b906011b52c6613376b1ae937670da69322113a246a09f807c62f6921
+        - 772e9f4c7db33d251d5c6e357199c819e569d130857dc225549b40845ff0890d
+        - aa315286e6ad281ad61182235533c41e806e5a787e0b6d1e7eef3f09d137d2e9
+        - fe331502606802feac15e514d9b9ea83fee8b6ffef71335479a2e68d84adc6b0
+        key-threshold: 3 # number of keys required
+
+        # ignore expiration date, see https://github.com/commercialhaskell/stack/pull/4614
+        ignore-expiry: no
+```
+
+### stack < v2.1.1
 
 修改`~/.stack/config.yaml`, 加上:
 

--- a/_posts/help/1970-01-01-hackage.md
+++ b/_posts/help/1970-01-01-hackage.md
@@ -61,7 +61,7 @@ remote-repo: mirrors.tuna.tsinghua.edu.cn:http://mirrors.tuna.tsinghua.edu.cn/ha
 
 ```yaml
 package-indices:
-  - download-prefix: http://mirrors.tuna.tsinghua.edu.cn/hackage
+  - download-prefix: http://mirrors.tuna.tsinghua.edu.cn/hackage/
     hackage-security:
         keyids:
         - 0a5c7ea47cd1b15f01f5f51a33adda7e655bc0f0b0615baa8e271f4c3351e21d

--- a/_posts/help/1970-01-01-hackage.md
+++ b/_posts/help/1970-01-01-hackage.md
@@ -6,7 +6,7 @@ mirrorid: hackage
 
 # hackage 镜像使用帮助
 
-## 在`cabel`中初次使用
+## 在`cabal`中初次使用
 
 先执行
 

--- a/_posts/help/1970-01-01-stackage.md
+++ b/_posts/help/1970-01-01-stackage.md
@@ -6,6 +6,20 @@ mirrorid: stackage
 
 ## stackage 镜像使用帮助
 
+本镜像推荐与 TUNA 的 [Hackage 镜像](https://mirrors.tuna.tsinghua.edu.cn/help/hackage/)配合使用。
+
+### stack >= v2.1.1
+
+修改`~/.stack/config.yaml`（在 Windows 下是 `%APPDATA%\stack\config.yaml`）, 加上:
+
+```yaml
+setup-info: "http://mirrors.tuna.tsinghua.edu.cn/stackage/stack-setup.yaml"
+urls:
+  latest-snapshot: http://mirrors.tuna.tsinghua.edu.cn/stackage/snapshots.json
+```
+
+### stack < v2.1.1
+
 修改`~/.stack/config.yaml`（在 Windows 下是 `%APPDATA%\stack\config.yaml`）, 加上:
 
 ```yaml
@@ -15,5 +29,3 @@ urls:
   lts-build-plans: http://mirrors.tuna.tsinghua.edu.cn/stackage/lts-haskell/
   nightly-build-plans: http://mirrors.tuna.tsinghua.edu.cn/stackage/stackage-nightly/
 ```
-
-推荐与 TUNA 的 [Hackage 镜像](https://mirrors.tuna.tsinghua.edu.cn/help/hackage/)配合使用。


### PR DESCRIPTION
根据 https://github.com/tuna/mirror-web/issues/132 ，stack v2.1.1增加了若干安全机制，相应地`config.yaml`文件的要求也改变了。

这里依照官方文档进行了修订。但需要tuna镜像同步好新增机制后，才能测试修订是否有效(Also see: https://github.com/tuna/tunasync-scripts/pull/37 )。由于缺少必要的环境，还请其他更方便的同学帮忙测试。

Refs:

* https://docs.haskellstack.org/en/stable/yaml_configuration/#package-indices
* https://docs.haskellstack.org/en/stable/yaml_configuration/#urls