### PR TITLE
Fix termux upgrade error

### DIFF
--- a/_posts/help/1970-01-01-termux.md
+++ b/_posts/help/1970-01-01-termux.md
@@ -34,7 +34,7 @@ Termux 是运行在 Android 上的 terminal。不需要root，运行于内部存
 
 ``` bash
 sed -i 's@^\(deb.*stable main\)$@#\1\ndeb https://mirrors.tuna.tsinghua.edu.cn/termux stable main@' $PREFIX/etc/apt/sources.list
-pkg up
+apt update && apt upgrade
 ```
 
 ### 手动修改
@@ -50,9 +50,16 @@ deb https://mirrors.tuna.tsinghua.edu.cn/termux stable main
 ### 报错与修复
 
 在Android P上使用TUNA源在upgrade的时候会出现报错
-```
+``` bash
 CANNOT LINK EXECUTABLE "dpkg-deb": library "libz.so.1" not found
 dpkg: error processing archive 
 ```
 此时退出 termux的进程，重新打开并`pkg up`即可修复。
+
+也可能出现以下报错
+``` bash
+CANNOT LINK EXECUTABLE "/data/data/com.termux/files/usr/lib/apt/methods/https": library "libnghttp2.so" not found
+CANNOT LINK EXECUTABLE "/data/data/com.termux/files/usr/lib/apt/methods/https": library "libnghttp2.so" not found
+```
+并且卡进度条，此时退出termux的进程,重新打开，并运行`dpkg --configure -a `即可修复。
 


### PR DESCRIPTION
经测试，`pkg up`所造成的很多玄学错误可有`apt update && apt upgrade`解决😂
（应该是`apt full-upgrade`覆盖了一些库的原因）