### PR TITLE
fix help for git-repo

### DIFF
--- a/_posts/help/1970-01-01-git-repo.md
+++ b/_posts/help/1970-01-01-git-repo.md
@@ -24,7 +24,7 @@ chmod +x repo
 repo的运行过程中会尝试访问官方的git源更新自己，如果想使用tuna的镜像源进行更新，可以将如下内容复制到你的`~/.bashrc`里
 
 ```
-export REPO_URL='https://mirrors.tuna.tsinghua.edu.cn/git/git-repo/'
+export REPO_URL='https://mirrors.tuna.tsinghua.edu.cn/git/git-repo'
 ```
 
 并重启终端模拟器。


### PR DESCRIPTION
REPO_URL ends with `/` will make repo fail

see https://github.com/tuna/issues/issues/676