### PR TITLE
NixOS new release format, take two

### DIFF
--- a/geninfo/genisolist.ini
+++ b/geninfo/genisolist.ini
@@ -395,6 +395,15 @@ type = $2 $4
 version = $1
 platform = $3
 
+[nixos]
+distro = NixOS
+listvers = 2
+location = nixos-images/nixos-*-small/latest-nixos-*-*-linux.*
+pattern = nixos-([0-9.]+)-small/latest-nixos-(\w+)-(i686|x86_64)-linux.(\w+)
+type = $2 $4, small channel
+version = $1
+platform = $3
+
 [eclipse]
 distro = Eclipse IDE
 listvers = 1

--- a/geninfo/genisolist.ini
+++ b/geninfo/genisolist.ini
@@ -388,7 +388,7 @@ category = app
 
 [nixos]
 distro = NixOS
-listvers = 1
+listvers = 2
 location = nixos-images/nixos-*/latest-nixos-*-*-linux.*
 pattern = nixos-([0-9.]+)/latest-nixos-(\w+)-(i686|x86_64)-linux.(\w+)
 type = $2 $4


### PR DESCRIPTION
1. Images for an unreleased version may appear. Before the format change, the upstream image name had a release number and we filtered out `beta` releases. Currently we work around this by listing two versions and relying on the user to pick the right one.
2. Add small channel.

For the actual syncing I don't know how to configure this, but nixos-images should contain these files:

```plain
s3://nix-channels/nixos-\d\d.\d\d(-small)?/latest-nixos-(\w+)-(i686|x86_64)-linux.(\w+)(.sha256)?
```