### PR TITLE
help: Debian: add ca-certificates for WSL

### DIFF
--- a/_posts/help/1970-01-01-debian.md
+++ b/_posts/help/1970-01-01-debian.md
@@ -19,6 +19,13 @@ $ sudo apt install apt-transport-https
 
 再使用 TUNA 的软件源镜像。
 
+如果使用的是 WSL (Windows Subsystem for Linux) ，请先安装：
+
+```
+$ sudo apt install ca-certificates
+```
+
+再使用 TUNA 的软件源镜像。
 
 <form class="form-inline">
 <div class="form-group">


### PR DESCRIPTION
WSL安装的Debian默认不带`ca-certificates`，直接换源会报错：`No system certificates available`