### PR TITLE
gentoo-portage帮助文档的修改

### DIFF
--- a/_posts/help/2017-12-29-gentoo-portage.md
+++ b/_posts/help/2017-12-29-gentoo-portage.md
@@ -6,6 +6,20 @@ mirrorid: gentoo-portage
 
 ## [Gentoo Linux](https://www.gentoo.org/) 的镜像配置方法如下：
 
+### Gentoo Portage 镜像配置：
+
+修改`/etc/portage/repos.conf/gentoo.conf`,将
+
+```
+sync-uri = rsync://rsync.gentoo.org/gentoo-portage
+```
+
+修改为
+
+```
+sync-uri = rsync://mirrors.tuna.tsinghua.edu.cn/gentoo-portage
+```
+
 ### Distfiles 配置：
 
 在 `/etc/portage/make.conf` 中加入：
@@ -14,4 +28,4 @@ mirrorid: gentoo-portage
 GENTOO_MIRRORS="https://{{ site.hostname }}/gentoo"
 ```
 
-执行 `emerge --sync` 或者 `eix-sync` 进行更新。
+配置好以上两项后,执行 `emerge --sync` 进行更新。

--- a/_posts/help/2017-12-29-gentoo-portage.md
+++ b/_posts/help/2017-12-29-gentoo-portage.md
@@ -8,7 +8,7 @@ mirrorid: gentoo-portage
 
 ### Gentoo Portage 镜像配置：
 
-修改`/etc/portage/repos.conf/gentoo.conf`,将
+修改 `/etc/portage/repos.conf/gentoo.conf` ,将
 
 ```
 sync-uri = rsync://rsync.gentoo.org/gentoo-portage

--- a/_posts/help/2017-12-29-gentoo-portage.md
+++ b/_posts/help/2017-12-29-gentoo-portage.md
@@ -17,7 +17,7 @@ sync-uri = rsync://rsync.gentoo.org/gentoo-portage
 修改为
 
 ```
-sync-uri = rsync://mirrors.tuna.tsinghua.edu.cn/gentoo-portage
+sync-uri = rsync://{{ site.hostname }}/gentoo-portage
 ```
 
 ### Distfiles 配置：


### PR DESCRIPTION
增加了对 repo 的配置(使得 `emerge --sync` 从 tuna 镜像仓库进行同步)
去除了 eix 相关内容(eix 并非系统自带,相关内容可能会给未安装 eix 的用户带来困扰)