### PR TITLE
Update Gentoo help document

### DIFF
--- a/_posts/help/2017-12-29-gentoo-portage.md
+++ b/_posts/help/2017-12-29-gentoo-portage.md
@@ -8,6 +8,8 @@ mirrorid: gentoo-portage
 
 ### Gentoo Portage 镜像配置：
 
+#### `rsync` 方式
+
 修改 `/etc/portage/repos.conf/gentoo.conf` ,将
 
 ```
@@ -19,6 +21,23 @@ sync-uri = rsync://rsync.gentoo.org/gentoo-portage
 ```
 sync-uri = rsync://{{ site.hostname }}/gentoo-portage
 ```
+
+#### `git` 方式
+
+第一次使用 `git` 同步方式的用户需要进行如下操作：
+
+- 修改 `/etc/portage/repos.conf/gentoo.conf`
+		- 将 `sync-type` 改為 `git`
+		- 將 `sync-uri` 改為 `https://{{ site.hostname }}/git/gentoo-portage.git`
+- 刪除 `/var/db/repos/gentoo`
+- 執行 `emerge --sync`
+
+已經配置 `git` 同步的用戶只需：
+
+- 修改 `/etc/portage/repos.conf/gentoo.conf`
+		- 將 `sync-uri` 改為 `https://{{ site.hostname }}/git/gentoo-portage.git`
+- 於 `/var/db/repos/gentoo` 下，執行 `git remote set-url origin https://{{ site.hostname }}/git/gentoo-portage.git`
+- 執行 `emerge --sync`
 
 ### Distfiles 配置：
 

--- a/_posts/help/2017-12-29-gentoo-portage.md
+++ b/_posts/help/2017-12-29-gentoo-portage.md
@@ -27,17 +27,17 @@ sync-uri = rsync://{{ site.hostname }}/gentoo-portage
 第一次使用 `git` 同步方式的用户需要进行如下操作：
 
 - 修改 `/etc/portage/repos.conf/gentoo.conf`
-		- 将 `sync-type` 改為 `git`
-		- 將 `sync-uri` 改為 `https://{{ site.hostname }}/git/gentoo-portage.git`
-- 刪除 `/var/db/repos/gentoo`
-- 執行 `emerge --sync`
+		- 将 `sync-type` 改为 `git`
+		- 将 `sync-uri` 改为 `https://{{ site.hostname }}/git/gentoo-portage.git`
+- 删除 `/var/db/repos/gentoo`
+- 执行 `emerge --sync`
 
-已經配置 `git` 同步的用戶只需：
+已经配置 `git` 同步的用户只需：
 
 - 修改 `/etc/portage/repos.conf/gentoo.conf`
-		- 將 `sync-uri` 改為 `https://{{ site.hostname }}/git/gentoo-portage.git`
-- 於 `/var/db/repos/gentoo` 下，執行 `git remote set-url origin https://{{ site.hostname }}/git/gentoo-portage.git`
-- 執行 `emerge --sync`
+		- 将 `sync-uri` 改为 `https://{{ site.hostname }}/git/gentoo-portage.git`
+- 于 `/var/db/repos/gentoo` 下，执行 `git remote set-url origin https://{{ site.hostname }}/git/gentoo-portage.git`
+- 执行 `emerge --sync`
 
 ### Distfiles 配置：
 

--- a/_posts/help/2020-02-21-gentoo-prefix.md
+++ b/_posts/help/2020-02-21-gentoo-prefix.md
@@ -4,7 +4,7 @@ layout: help
 mirrorid: gentoo-portage-prefix
 ---
 
-**注意：Gentoo Prefix Portage tree 已合併進 gentoo.git。如果您是 Linux 用戶，請使用 `gentoo-portage` rsync 或 git 鏡像。此 repo 專為 macOS 下 prefix 用戶而設。**
+**注意：Gentoo Prefix Portage tree 已合并进 gentoo.git。如果您是 Linux 用户，请使用 `gentoo-portage` rsync 或 git 镜像。此 repo 专为 macOS 下 prefix 用户而设。**
 
 ## [Gentoo Prefix](https://wiki.gentoo.org/wiki/Project:Prefix) macOS 的镜像配置方法如下：
 

--- a/_posts/help/2020-02-21-gentoo-prefix.md
+++ b/_posts/help/2020-02-21-gentoo-prefix.md
@@ -4,7 +4,9 @@ layout: help
 mirrorid: gentoo-portage-prefix
 ---
 
-## [Gentoo Prefix](https://wiki.gentoo.org/wiki/Project:Prefix) 的镜像配置方法如下：
+**注意：Gentoo Prefix Portage tree 已合併進 gentoo.git。如果您是 Linux 用戶，請使用 `gentoo-portage` rsync 或 git 鏡像。此 repo 專為 macOS 下 prefix 用戶而設。**
+
+## [Gentoo Prefix](https://wiki.gentoo.org/wiki/Project:Prefix) macOS 的镜像配置方法如下：
 
 ### Bootstrap 镜像配置：
 

--- a/_posts/help/2020-05-05-gentoo-portage.git.md
+++ b/_posts/help/2020-05-05-gentoo-portage.git.md
@@ -1,0 +1,6 @@
+---
+category: help
+layout: help
+mirrorid: gentoo-portage.git
+redirect_help_id: gentoo-portage
+---


### PR DESCRIPTION
Add instructions to enable/update git sync method for Gentoo portage repo.

Note that this pull request is not yet in good shape.  Waiting for @Harry-Chen to:

- [x] figure out the proper way to unify help pages for different repositories
- [x] fix incorrect HEAD commit in `gentoo-portage.git` mirror