### PR TITLE
改进镜像列表中的帮助链接

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -37,7 +37,7 @@
 										<span class="label label-new">new</span>
 										{{/if}}
 										{{if help_url}}
-										<a href="{{help_url}}"><i class="fa fa-question-circle" title="Help"></i></a>
+										<a href="{{help_url}}"><i aria-hidden="true" class="fa fa-question-circle" title="Help"></i><span class="sr-only">[Help]</span></a>
 										{{/if}}
 									</td>
 									<td>
@@ -54,7 +54,7 @@
 											:data-content="mir.description" :href="getURL(mir)" :aria-label="mir.name + ', ' + mir.description">
 											{{mir.name}}
 											<span class="label label-new" v-if='mir.is_new'>new</span>
-											<a v-if='mir.help_url' :href="mir.help_url"><i class="fa fa-question-circle" title="Help"></i></a>
+											<a v-if='mir.help_url' :href="mir.help_url"><i aria-hidden="true" class="fa fa-question-circle" title="Help"></i><span class="sr-only">[Help]</span></a>
 										</a>
 									</td>
 									<td class="col-md-4">


### PR DESCRIPTION
镜像列表中的帮助链接目前为单个Font Awsome标志，对于命令行浏览器和屏幕阅读器用户并不友好。此PR为其添加了`sr-only`的文字替代。`sr-only`类由bootstrap定义，在支持CSS的现代浏览器中不会显示，但在不支持CSS `clip`的命令行浏览器和屏幕阅读器中会正常工作。

参见：
* [Bootstrap Screenreaders](https://getbootstrap.com/docs/4.0/utilities/screenreaders/)
* [FontAwsome Accessibility](https://fontawesome.com/how-to-use/on-the-web/other-topics/accessibility)

修改前在`elinks`中的效果：
![before](https://user-images.githubusercontent.com/8182182/82778644-f7653000-9e1f-11ea-97d0-d7e6bd926495.png)

修改后：
![after](https://user-images.githubusercontent.com/8182182/82778676-0b109680-9e20-11ea-9238-c540a93f63c1.png)

