### PR TITLE
fix julia regex to not match *.asc files

### DIFF
--- a/geninfo/genisolist.ini
+++ b/geninfo/genisolist.ini
@@ -627,7 +627,7 @@ distro = Julia
 listvers = 1
 location = julia-releases/bin/*/*/*/julia-*
 # This regex does not capture release candidate (rc) versions
-pattern = /bin/(freebsd|mac|linux|winnt)/(x64|x86|aarch64|armv7l)/[\w\.]+/julia-(\d+\.\d+\.\d+)-\w+-?\w+\.(dmg|pkg|exe|tar\.gz)
+pattern = /bin/(freebsd|mac|linux|winnt)/(x64|x86|aarch64|armv7l)/[\w\.]+/julia-(\d+\.\d+\.\d+)-\w+-?\w+\.(dmg|pkg|exe|tar\.gz)(?!.)
 platform = $1/$2
 version = $3
 type = $4


### PR DESCRIPTION
实在是不太熟悉regex 😂 ... 之前的匹配忘记检查结尾了，所以导致 asc 文件也被匹配到了

![image](https://user-images.githubusercontent.com/8684355/82993004-88abf080-a032-11ea-9d7c-82e8c811ec21.png)
