### PR TITLE
[julia] correct bash usage and add some more notes

### DIFF
--- a/_posts/help/2020-05-25-julia.md
+++ b/_posts/help/2020-05-25-julia.md
@@ -13,14 +13,29 @@ TUNA 同时也提供了 Julia 二进制程序的镜像，关于其使用请参�
 
 ## 使用方式
 
-只需要设置环境变量 `JULIA_PKG_SERVER` 即可切换镜像。若不设置该环境变量则默认使用官方服务器 `pkg.julialang.org` 作为
-上游。
+只需要设置环境变量 `JULIA_PKG_SERVER` 即可切换镜像。若成功切换镜像，则能通过`versioninfo()`查询到相关信息，例如：
+
+```julia
+julia> versioninfo()
+Julia Version 1.4.1
+Commit 381693d3df* (2020-04-14 17:20 UTC)
+Platform Info:
+  OS: Linux (x86_64-pc-linux-gnu)
+  CPU: Intel(R) Core(TM) i7-6800K CPU @ 3.40GHz
+  WORD_SIZE: 64
+  LIBM: libopenlibm
+  LLVM: libLLVM-8.0.1 (ORCJIT, broadwell)
+Environment:
+  JULIA_PKG_SERVER = https://{{ site.hostname }}/julia/static
+```
+
+若不设置该环境变量则默认使用官方服务器 `pkg.julialang.org` 作为上游。
 
 ### 临时使用
 
 不同系统和命令行下设置环境变量的方式各不相同，在命令行下可以通过以下方式来临时修改环境变量
 
-* Linux Bash: `JULIA_PKG_SERVER=https://{{ site.hostname }}/julia/static`
+* Linux Bash: `export JULIA_PKG_SERVER=https://{{ site.hostname }}/julia/static`
 * Windows Powershell: `$env:JULIA_PKG_SERVER = 'https://{{ site.hostname }}/julia/static'`
 
 ### 永久使用


### PR DESCRIPTION
I use `JULIA_PKG_SERVER="..." julia` too often that I forget an `export` is necessary in this case. Hope this is my last mistake in the documentation :sob:

We're working on an easier setup in JuliaZH, an l10n package tailored to Chinese users. When that's released, we'll update the documentation one more time.