### PR TITLE
[julia] use built-in registry functionality to re-pull General

### DIFF
--- a/_posts/help/2020-05-25-julia.md
+++ b/_posts/help/2020-05-25-julia.md
@@ -96,17 +96,14 @@ julia> JuliaZH.generate_startup("BFSU")
 ### 为什么注册表还是从原地址下载？
 
 Julia `v1.4.0` 之前的版本采用的是 `git clone` 的方式拉取注册表。为了保持兼容性，如果现有的注册表是一个完整的 git 仓库的话，
-那么即使设置了上游镜像也依然会通过 `git` 来进行更新，换句话说，不会通过镜像站来下载注册表数据。
+那么即使设置了 PkgServer 作为上游镜像也依然会通过 `git` 来进行更新，换句话说，不会通过镜像站来下载注册表数据。
 
-以默认注册表 `General` 为例，在设置好 `JULIA_PKG_SERVER` 的情况下可以通过重置 `General` 来切换到镜像站：
+以默认注册表 `General` 为例，只需要手动将其重置到镜像站即可：
 
-```julia
-(@v1.4) pkg>  ]registry rm General
-# 此时会从 PkgServer 来下载 General 而不是从 Github 进行 git clone
-(@v1.4) pkg>  ]registry add General
-```
-
-但是这样一来，在**使用旧版本 Julia 时就会因为不兼容而无法更新注册表**，因此最好根据自己的使用场景来确定是否要这样做。
+1. 删除当前注册表：`(@v1.4) pkg> registry rm General`
+2. 从镜像站下载/拉取注册表（二选一）：
+    * (PkgServer)： `(@v1.4) pkg> registry add General` -- 因为不兼容的原因，旧的 Julia 版本将无法更新注册表
+    * (Git Repo)：`(@v1.4) pkg> registry add https://{{ site.hostname }}/git/julia-general.git` -- 依然兼容早期 Julia 版本
 
 ### 为什么有些包还是从原地址下载？
 

--- a/_posts/help/2020-05-25-julia.md
+++ b/_posts/help/2020-05-25-julia.md
@@ -95,11 +95,18 @@ julia> JuliaZH.generate_startup("BFSU")
 
 ### 为什么注册表还是从原地址下载？
 
-Julia `v1.4.0` 之前的版本采用的是 `git clone` 的方式拉取注册表，所以为了保持兼容性，即使设置上游镜像也依然会通过 `git` 来进行更新。
+Julia `v1.4.0` 之前的版本采用的是 `git clone` 的方式拉取注册表。为了保持兼容性，如果现有的注册表是一个完整的 git 仓库的话，
+那么即使设置了上游镜像也依然会通过 `git` 来进行更新，换句话说，不会通过镜像站来下载注册表数据。
 
-以 `General` 为例，可以通过删除 `$JULIA_DEPOT_PATH/registries/General`（默认为 `~/.julia/registries/General`)
-文件夹来重置，从而在下次更新时从镜像站拉取一份新的 `General`. 但是这样一来，在旧版本 Julia 中就无法对注册表进行更新，
-因此最好需要根据自己的使用场景来权衡。
+以默认注册表 `General` 为例，在设置好 `JULIA_PKG_SERVER` 的情况下可以通过重置 `General` 来切换到镜像站：
+
+```julia
+(@v1.4) pkg>  ]registry rm General
+# 此时会从 PkgServer 来下载 General 而不是从 Github 进行 git clone
+(@v1.4) pkg>  ]registry add General
+```
+
+但是这样一来，在**使用旧版本 Julia 时就会因为不兼容而无法更新注册表**，因此最好根据自己的使用场景来确定是否要这样做。
 
 ### 为什么有些包还是从原地址下载？
 

--- a/_posts/help/2020-06-05-julia-general.git.md
+++ b/_posts/help/2020-06-05-julia-general.git.md
@@ -1,0 +1,16 @@
+## Julia 默认注册表 General 仓库镜像
+
+该镜像仅为 Julia 默认注册表 [General](https://github.com/JuliaRegistries/General) 仓库的 Git 镜像。
+若需要包括 Julia 包以及二进制依赖在内的完整的镜像，请参考 [Julia 镜像使用帮助]({{ site.url }}/help/julia/)。
+
+## 使用方式
+
+Julia 包注册表存放在`$JULIA_DEPOT_PATH/registries`(默认为 `~/.julia/registries`) 文件夹下。以默认情况为例：
+
+1. 若存在的话，删除原有的 `General`: `rm -rf ~/.julia/registries/General`
+2. 将该镜像克隆到对应目录下：`git clone https://{{ site.hostname }}/git/julia-general.git ~/.julia/registries/General`
+
+对于 Julia `v1.1` 及以后版本，可以通过 Julia 内置的注册表管理功能来做到：
+
+1. `(@v1.4) pkg> registry rm General`
+2. `(@v1.4) pkg> registry add https://{{ site.hostname }}/git/julia-general.git`


### PR DESCRIPTION
> 但是这样一来，在**使用旧版本 Julia 时就会因为不兼容而无法更新注册表**，因此最好根据自己的使用场景来确定是否要这样做。

实际上，若能够提供一个 General 的镜像仓库的话，可以通过下面这种方式来添加 git repo 形式的 General，这样就能避免 <=1.3 的 Julia 版本无法更新注册表的问题。

```julia
(@v1.4) pkg>  ]registry add http://mirrors.bfsu.edu.cn/julia/static/registries/General.git/
```

目前国内有的 General repo 镜像：

* USTC: http://mirrors.ustc.edu.cn/julia/registries/General.git/
* Gitee: https://gitee.com/JohnnyChen94/General （我个人维护的）

但我不太确定把这些非TUNA镜像的使用添加到这里是否合适。不知道能不能在 BFSU 上再额外提供一个 git repo 的镜像（不太清楚这种镜像该怎么部署到nginx上）？

CRef: https://github.com/JuliaLang/Pkg.jl/issues/1845