### PR TITLE
Add Debian netinst into download list

### DIFF
--- a/geninfo/genisolist.ini
+++ b/geninfo/genisolist.ini
@@ -157,6 +157,16 @@ version = $1
 type = CD installer with $3
 platform = $2
 
+[debian_netinst]
+distro = Debian
+listvers = 1
+location_0 = debian-cd/current/amd64/iso-cd/debian-*-amd64-netinst.iso
+location_1 = debian-cd/current/i386/iso-cd/debian-*-i386-netinst.iso
+pattern = debian-([0-9.]+)-(\w+)-netinst.iso
+version = $1
+type = Network installer
+platform = $2
+
 [debian_dvd]
 distro = Debian
 listvers = 1


### PR DESCRIPTION
Hi, 
我是一个 Debian 用户，在使用镜像站的下载链接列表的时候没有发现 Debian netinst 镜像，
所以在这里添加了一个。平时获取的都是 netinst 镜像，但需要手动导航到相应目录
下载。

祝好。