### PR TITLE
Add Debian NonFree

### DIFF
--- a/geninfo/genisolist.ini
+++ b/geninfo/genisolist.ini
@@ -12,6 +12,7 @@ root = /data/
 urlbase = /
 d10 = Arch Linux
 d20 = Debian
+d21 = Debian NonFree
 d25 = CentOS
 d30 = Fedora
 d40 = Ubuntu
@@ -167,16 +168,6 @@ version = $1
 type = Network installer
 platform = $2
 
-[debian_netinst_nonfree]
-distro = Debian
-listvers = 1
-location_0 = debian-nonfree/cd-including-firmware/current/amd64/iso-cd/firmware-*-amd64-netinst.iso
-location_1 = debian-nonfree/cd-including-firmware/current/i386/iso-cd/firmware-*-i386-netinst.iso
-pattern = firmware-([0-9.]+)-(\w+)-netinst.iso
-version = $1
-type = Network installer with non-free firmware
-platform = $2
-
 [debian_dvd]
 distro = Debian
 listvers = 1
@@ -195,6 +186,36 @@ location_1 = debian-cd/current-live/i386/iso-hybrid/debian-live-*-i386-*.iso
 pattern = debian-live-([0-9.]+)-(\w+)-(\w+).iso
 version = $1
 type = Live CD with $3
+platform = $2
+
+[debian_netinst_nonfree]
+distro = Debian NonFree
+listvers = 1
+location_0 = debian-nonfree/cd-including-firmware/current/amd64/iso-cd/firmware-*-amd64-netinst.iso
+location_1 = debian-nonfree/cd-including-firmware/current/i386/iso-cd/firmware-*-i386-netinst.iso
+pattern = firmware-([0-9.]+)-(\w+)-netinst.iso
+version = $1
+type = Network installer with non-free firmware
+platform = $2
+
+[debian_dvd_nonfree]
+distro = Debian NonFree
+listvers = 1
+location_0 = debian-nonfree/cd-including-firmware/current/amd64/iso-dvd/firmware-*-amd64-DVD-*.iso
+location_1 = debian-nonfree/cd-including-firmware/current/i386/iso-dvd/firmware-*-amd64-DVD-*.iso
+pattern = firmware-([0-9.]+)-(\w+)-DVD-(\d).iso
+version = $1
+type = DVD installer with non-free firmware (Part $3)
+platform = $2
+
+[debian_live_nonfree]
+distro = Debian NonFree
+listvers = 1
+location_0 = debian-nonfree/images-including-firmware/current-live/amd64/iso-hybrid/debian-live-*-amd64-*+nonfree.iso
+location_1 = debian-nonfree/images-including-firmware/current-live/i386/iso-hybrid/debian-live-*-amd64-*+nonfree.iso
+pattern = debian-live-([0-9.]+)-(\w+)-(\w+)\+nonfree.iso
+version = $1
+type = Live CD with $3 and non-free firmware
 platform = $2
 
 [centos]


### PR DESCRIPTION
Add Debian {netinst,dvd,live} with non-free firmware to a separate distribution tab.