### PR TITLE
[julia] display rc version suffixes in genisolist

### DIFF
--- a/geninfo/genisolist.ini
+++ b/geninfo/genisolist.ini
@@ -677,12 +677,11 @@ category = app
 distro = Julia
 listvers = 1
 location = julia-releases/bin/*/*/*/julia-*
-# This regex does not capture release candidate (rc) versions
-pattern = /bin/(freebsd|mac|linux|winnt)/(x64|x86|aarch64|armv7l)/[\w\.]+/julia-(\d+\.\d+\.\d+)-\w+-?\w+\.(dmg|pkg|exe|tar\.gz)(?!.)
+pattern = /bin/(freebsd|mac|linux|winnt)/(x64|x86|aarch64|armv7l)/([\d\.]+)/julia-([\d\.]+-?(alpha|beta|rc)?\d?)-\w+\.(dmg|pkg|exe|tar\.gz)(?!.)
 platform = $1/$2
-version = $3
-type = $4
-key_by = $1 $2
+version = $4
+type = $6
+key_by = $1 $3
 category = app
 
 [adobe source fonts]


### PR DESCRIPTION
The previous version actually captures RC and beta versions, but display
it incorrectly. This commit fixes the regex to display the rc/beta suffix.

这里实际上有一个显示的错误：应该应该显示 1.5.0-rc1 和 1.5.0-beta1 的

![image](https://user-images.githubusercontent.com/8684355/87203345-fbe49a00-c334-11ea-8b24-4769e88361ee.png)
