### PR TITLE
[julia] do not capture test and rc versions 

### DIFF
--- a/geninfo/genisolist.ini
+++ b/geninfo/genisolist.ini
@@ -677,11 +677,12 @@ category = app
 distro = Julia
 listvers = 1
 location = julia-releases/bin/*/*/*/julia-*
-pattern = /bin/(freebsd|mac|linux|winnt)/(x64|x86|aarch64|armv7l)/([\d\.]+)/julia-([\d\.]+-?(alpha|beta|rc)?\d?)-\w+\.(dmg|pkg|exe|tar\.gz)(?!.)
+# This regex does not capture release candidate (rc) versions
+pattern = /bin/(freebsd|mac|linux|winnt)/(x64|x86|aarch64|armv7l)/[\w\.]+/julia-(\d+\.\d+\.\d+)-\w+-?\w+\.(dmg|pkg|exe|tar\.gz)(?!.)
 platform = $1/$2
-version = $4
-type = $6
-key_by = $1 $3
+version = $3
+type = $4
+key_by = $1 $2
 category = app
 
 [adobe source fonts]

--- a/geninfo/genisolist.ini
+++ b/geninfo/genisolist.ini
@@ -678,11 +678,11 @@ distro = Julia
 listvers = 1
 location = julia-releases/bin/*/*/*/julia-*
 # This regex does not capture release candidate (rc) versions
-pattern = /bin/(freebsd|mac|linux|winnt)/(x64|x86|aarch64|armv7l)/[\w\.]+/julia-(\d+\.\d+\.\d+)-\w+-?\w+\.(dmg|pkg|exe|tar\.gz)(?!.)
-platform = $1/$2
-version = $3
+pattern = /(x64|x86|aarch64|armv7l)/[\d\.]+/julia-([\d\.]+)-(freebsd|mac|linux|win)\d*-?\w+\.(dmg|pkg|exe|tar\.gz)(?!.)
+platform = $3/$2
+version = $2
 type = $4
-key_by = $1 $2
+key_by = $3 $2
 category = app
 
 [adobe source fonts]


### PR DESCRIPTION
This reverts commit 9fdf2a4e8e34bf26db05cd9bac03a868eb709783 because it fails to sort versions correctly if we include rc versions

匹配rc版本之后大概因为排序的原因没有把 `1.2.0` 正式版给显示出来，所以这次直接不匹配rc和测试版

![image](https://user-images.githubusercontent.com/8684355/87217021-8bab3800-c377-11ea-9b58-7585a1d4f88e.png)

![image](https://user-images.githubusercontent.com/8684355/87217302-44727680-c37a-11ea-87dd-0fed33f69686.png)



本地好像没办法直接生成数据，所以只能反复尝试... 希望这是最后一次调整