### PR TITLE
[julia] fix platform label in genisolist

### DIFF
--- a/geninfo/genisolist.ini
+++ b/geninfo/genisolist.ini
@@ -679,7 +679,7 @@ listvers = 1
 location = julia-releases/bin/*/*/*/julia-*
 # This regex does not capture release candidate (rc) versions
 pattern = /(x64|x86|aarch64|armv7l)/[\d\.]+/julia-([\d\.]+)-(freebsd|mac|linux|win)\d*-?\w+\.(dmg|pkg|exe|tar\.gz)(?!.)
-platform = $3/$2
+platform = $3/$1
 version = $2
 type = $4
 key_by = $3 $2


### PR DESCRIPTION
platform应该是 `$sys/$arch` 这种，#206 里误操作把它改成 `$sys/$version` 了