### PR TITLE
添加Android-x86镜像下载

### DIFF
--- a/geninfo/genisolist.ini
+++ b/geninfo/genisolist.ini
@@ -494,7 +494,7 @@ sort_by = $3 $1
 
 [android-x86]
 distro = Android-x86
-listvers = 10
+listvers = 1000
 location = osdn/android-x86/*/*.iso
 pattern = (android|cm)-(x86_64|x86)?-?(.+).iso
 version = $2


### PR DESCRIPTION
匹配 Android-x86 v1.6-现在 所有版本的iso文件，方便Android开发调试使用