### PR TITLE
重新修正Android-x86与cm-x86

### DIFF
--- a/geninfo/genisolist.ini
+++ b/geninfo/genisolist.ini
@@ -500,7 +500,7 @@ version = $2
 type = $3
 platform = $1
 key_by = $2 $3 $1
-sort_by = $3 $2 $1
+sort_by = $2 $3 $1
 
 [cm-x86]
 distro = Android-x86
@@ -511,7 +511,7 @@ version = $2
 type = $3 , based on Lineage OS
 platform = $1
 key_by = $2 $3 $1
-sort_by = $3 $2 $1
+sort_by = $2 $3 $1
 
 [docker mac]
 distro = Docker


### PR DESCRIPTION
1. 把一个不可饶恕的错误改了过来，之前的pr打错了，该是版本号匹配成架构去了
![正则表达式不规范的后果](https://ftp.bmp.ovh/imgs/2020/08/b801c5e49db9eed4.png)

2. 分离`Android-x86`与`cm-x86`（基于Lineage OS的分支）

修正之后，如无误会如`6.0 (x86_64, rc2-for-s3)`的格式显示