### PR TITLE
暂时从 genisolist.ini 移除 Deepin 镜像

### DIFF
--- a/geninfo/genisolist.ini
+++ b/geninfo/genisolist.ini
@@ -17,7 +17,7 @@ d25 = CentOS
 d30 = Fedora
 d40 = Ubuntu
 d50 = Ubuntu 衍生版
-d60 = Deepin
+# d60 = Deepin
 
 # Sections whose name isn't "%main%" defined a detect rule of image detection.
 [archlinux]
@@ -307,13 +307,13 @@ pattern = MX-([0-9\.]+)_(\w+)\.iso
 version = $1
 platform = $2
 
-[deepin]
-distro = Deepin
-listvers = 1
-location = deepin-cd/1*/*.iso
-pattern = deepin-([0-9.]+)-(\w+).iso
-version = $1
-platform = $2
+# [deepin]
+# distro = Deepin
+# listvers = 1
+# location = deepin-cd/1*/*.iso
+# pattern = deepin-([0-9.]+)-(\w+).iso
+# version = $1
+# platform = $2
 
 [raspberry-pi-os-images]
 distro = Raspberry Pi OS (原 Raspbian)


### PR DESCRIPTION
[原因](https://mirrors.tuna.tsinghua.edu.cn/news/close-deepin/)

想想吧，用户点进去然后`403` :thinking: