### PR TITLE
Update to Deepin 20

### DIFF
--- a/geninfo/genisolist.ini
+++ b/geninfo/genisolist.ini
@@ -307,14 +307,14 @@ pattern = MX-([0-9\.]+)_(\w+)\.iso
 version = $1
 platform = $2
 
-[deepin20]
+[deepin]
 distro = Deepin
-listvers = 1
-location = deepin-cd/20/*.iso
-pattern = deepin-([0-9.]+)-(\w+).iso
-version = 20
-platform = $2
-type = $1
+listvers = 10
+location = deepin-cd/*/*.iso
+pattern = deepin-cd/(.+)/deepin-(.+)-(\w+).iso
+version = $1
+platform = $3
+type = $2
 
 [raspberry-pi-os-images]
 distro = Raspberry Pi OS (原 Raspbian)

--- a/geninfo/genisolist.ini
+++ b/geninfo/genisolist.ini
@@ -307,13 +307,14 @@ pattern = MX-([0-9\.]+)_(\w+)\.iso
 version = $1
 platform = $2
 
-[deepin]
+[deepin20]
 distro = Deepin
 listvers = 1
-location = deepin-cd/[0-9]*/*.iso
+location = deepin-cd/20/*.iso
 pattern = deepin-([0-9.]+)-(\w+).iso
-version = $1
+version = 20
 platform = $2
+type = $1
 
 [raspberry-pi-os-images]
 distro = Raspberry Pi OS (原 Raspbian)

--- a/geninfo/genisolist.ini
+++ b/geninfo/genisolist.ini
@@ -310,7 +310,7 @@ platform = $2
 [deepin]
 distro = Deepin
 listvers = 1
-location = deepin-cd/1*/*.iso
+location = deepin-cd/[0-9]*/*.iso
 pattern = deepin-([0-9.]+)-(\w+).iso
 version = $1
 platform = $2


### PR DESCRIPTION
`deepin-cd`镜像恢复之后快捷下载居然没了，一查原来deepin子目只匹配`1x`时代的镜像