### PR TITLE
Fix git remotes in Homebrew help due to upstream changes

### DIFF
--- a/help/_posts/1970-01-01-homebrew.md
+++ b/help/_posts/1970-01-01-homebrew.md
@@ -13,31 +13,34 @@ mirrorid: homebrew
 首先，需要确保系统中安装了 bash、git 和 curl，对于 macOS 用户需额外要求安装 Command Line Tools (CLT) for Xcode。
 
 - 对于 macOS 用户，系统自带 bash、git 和 curl，在命令行输入 `xcode-select --install` 安装 CLT for Xcode 即可。
-- 对于 Linux 用户，系统自带 bash，仅需额外安装 git 即可（curl 为 git 的依赖项会自动安装）。
+- 对于 Linux 用户，系统自带 bash，仅需额外安装 git 和 curl。
 
-接着，在终端输入以下两行命令设置环境变量：
+接着，在终端输入以下几行命令设置环境变量：
 
 ```bash
-# macOS 用户，请使用以下两句命令
-export HOMEBREW_CORE_GIT_REMOTE="https://{{ site.hostname }}/git/homebrew/homebrew-core.git"
-export HOMEBREW_BOTTLE_DOMAIN="https://{{ site.hostname }}/homebrew-bottles"
-# Linux 用户，请使用以下两句命令
-# export HOMEBREW_CORE_GIT_REMOTE="https://{{ site.hostname }}/git/homebrew/linuxbrew-core.git"
-# export HOMEBREW_BOTTLE_DOMAIN="https://{{ site.hostname }}/linuxbrew-bottles"
+if [[ "$(uname -s)" == "Linux" ]]; then BREW_TYPE="linuxbrew"; else BREW_TYPE="homebrew"; fi
+export HOMEBREW_BREW_GIT_REMOTE="https://{{ site.hostname }}/git/homebrew/brew.git"
+export HOMEBREW_CORE_GIT_REMOTE="https://{{ site.hostname }}/git/homebrew/${BREW_TYPE}-core.git"
+export HOMEBREW_BOTTLE_DOMAIN="https://{{ site.hostname }}/${BREW_TYPE}-bottles"
 ```
 
 最后，在终端运行以下命令以安装 Homebrew / Linuxbrew：
 
 ```bash
-# 从本镜像下载安装脚本，修改其中的仓库源并安装 Homebrew / Linuxbrew
+# 从本镜像下载安装脚本，修改其中被硬编码的仓库源（改为从环境变量读入）并安装 Homebrew / Linuxbrew
 git clone --depth=1 https://{{ site.hostname }}/git/homebrew/install.git brew-install
-/bin/bash -c "$(sed 's|^HOMEBREW_BREW_GIT_REMOTE=.*$|HOMEBREW_BREW_GIT_REMOTE="https://{{ site.hostname }}/git/homebrew/brew.git"|g' brew-install/install.sh)"
+/bin/bash -c "$(
+    cat brew-install/install.sh |
+    sed -E 's|^(\s*HOMEBREW_BREW_GIT_REMOTE=)(.*)$|\1"${HOMEBREW_BREW_GIT_REMOTE:-\2}"|g' |
+    sed -E 's|^(\s*HOMEBREW_CORE_GIT_REMOTE=)(.*)$|\1"${HOMEBREW_CORE_GIT_REMOTE:-\2}"|g'
+)"
 rm -rf brew-install
 
-# 也可从 GitHub 获取官方安装脚本，修改其中的仓库源，运行以安装 Homebrew / Linuxbrew
+# 也可从 GitHub 获取官方安装脚本，修改其中被硬编码的仓库源，运行以安装 Homebrew / Linuxbrew
 /bin/bash -c "$(
     curl -fsSL https://github.com/Homebrew/install/raw/master/install.sh |
-    sed 's|^HOMEBREW_BREW_GIT_REMOTE=.*$|HOMEBREW_BREW_GIT_REMOTE="https://{{ site.hostname }}/git/homebrew/brew.git"|g'
+    sed -E 's|^(\s*HOMEBREW_BREW_GIT_REMOTE=)(.*)$|\1"${HOMEBREW_BREW_GIT_REMOTE:-\2}"|g' |
+    sed -E 's|^(\s*HOMEBREW_CORE_GIT_REMOTE=)(.*)$|\1"${HOMEBREW_CORE_GIT_REMOTE:-\2}"|g'
 )"
 ```
 


### PR DESCRIPTION
brew 官方安装脚本又硬编码了 `HOMEBREW_CORE_GIT_REMOTE`，改为从环境变量读入。