### PR TITLE
brew v3.0.7开始,HOMEBREW_BOTTLE_DOMAIN需要指定到/bottles这一级路径

### DIFF
--- a/help/_posts/1970-01-01-linuxbrew-bottles.md
+++ b/help/_posts/1970-01-01-linuxbrew-bottles.md
@@ -11,7 +11,7 @@ mirrorid: linuxbrew-bottles
 ### 临时替换
 
 ```bash
-export HOMEBREW_BOTTLE_DOMAIN="https://{{ site.hostname }}/linuxbrew-bottles"
+export HOMEBREW_BOTTLE_DOMAIN="https://{{ site.hostname }}/linuxbrew-bottles/bottles"
 ```
 
 ### 长期替换
@@ -19,14 +19,14 @@ export HOMEBREW_BOTTLE_DOMAIN="https://{{ site.hostname }}/linuxbrew-bottles"
 如果你使用 bash：
 
 ```bash
-test -r ~/.bash_profile && echo 'export HOMEBREW_BOTTLE_DOMAIN="https://{{ site.hostname }}/linuxbrew-bottles"' >> ~/.bash_profile
-test -r ~/.profile && echo 'export HOMEBREW_BOTTLE_DOMAIN="https://{{ site.hostname }}/linuxbrew-bottles"' >> ~/.profile
-export HOMEBREW_BOTTLE_DOMAIN="https://{{ site.hostname }}/linuxbrew-bottles"
+test -r ~/.bash_profile && echo 'export HOMEBREW_BOTTLE_DOMAIN="https://{{ site.hostname }}/linuxbrew-bottles/bottles"' >> ~/.bash_profile
+test -r ~/.profile && echo 'export HOMEBREW_BOTTLE_DOMAIN="https://{{ site.hostname }}/linuxbrew-bottles/bottles"' >> ~/.profile
+export HOMEBREW_BOTTLE_DOMAIN="https://{{ site.hostname }}/linuxbrew-bottles/bottles"
 ```
 
 如果你使用 zsh：
 
 ```zsh
-echo 'export HOMEBREW_BOTTLE_DOMAIN="https://{{ site.hostname }}/linuxbrew-bottles"' >> ~/.zprofile
-export HOMEBREW_BOTTLE_DOMAIN="https://{{ site.hostname }}/linuxbrew-bottles"
+echo 'export HOMEBREW_BOTTLE_DOMAIN="https://{{ site.hostname }}/linuxbrew-bottles/bottles"' >> ~/.zprofile
+export HOMEBREW_BOTTLE_DOMAIN="https://{{ site.hostname }}/linuxbrew-bottles/bottles"
 ```


### PR DESCRIPTION
参考[brew Release 3.0.7发布内容](https://github.com/Homebrew/brew/releases/tag/3.0.7)的参考，去除了对/bottles这级路径的拼接，因此目前得类似：`HOMEBREW_BOTTLE_DOMAIN=https://mirrors.ustc.edu.cn/homebrew-bottles/bottles`如此。

参考：

 - [github_packages: fix HOMEBREW_BOTTLE_DOMAIN usage.](https://github.com/Homebrew/brew/pull/10863)