### PR TITLE
支持非根URL/Add support for non-base url

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,24 +6,24 @@
 {% endif %}{{ site.title }}，致力于为国内和校内用户提供高质量的开源软件镜像、Linux 镜像源服务，帮助用户更方便地获取开源软件。本镜像站由清华大学 TUNA 团队负责维护。">
 <meta name="keywords" content="镜像站,镜像源,Linux,软件源,开源">
 <meta name="author" content="TUNA">
-<link rel="shortcut icon" href="/static/img/favicon.png">
+<link rel="shortcut icon" href="{{ site.baseurl }}/static/img/favicon.png">
 <title>{% if page.mirrorid %} {{ page.mirrorid }} |{% elsif page.title %} {{ page.title }} |{% endif %}{% if include.cattitle %} {{ include.cattitle }} |{% endif %}{% if (page.title or include.cattitle) %}{{" "}}{% endif %}{{ site.title }}{% if site.brand %} | {{ site.brand }}{% endif %}</title>
 {% unless include.nostyle %}
-<link rel="stylesheet" href="/static/css/bootstrap.css">
-<link rel="stylesheet" href="/static/css/bootstrap-select.min.css">
-<link rel="stylesheet" href="/static/css/font-awesome.min.css" >
-<link rel="stylesheet" href="/static/css/spinkit.css">
-<link rel="stylesheet" href="/static/css/style.css">
-<script src="/static/js/jquery.min.js"></script>
-<script src="/static/js/bootstrap.min.js"></script>
-<script src="/static/js/bootstrap-select.min.js"></script>
+<link rel="stylesheet" href="{{ site.baseurl }}/static/css/bootstrap.css">
+<link rel="stylesheet" href="{{ site.baseurl }}/static/css/bootstrap-select.min.css">
+<link rel="stylesheet" href="{{ site.baseurl }}/static/css/font-awesome.min.css" >
+<link rel="stylesheet" href="{{ site.baseurl }}/static/css/spinkit.css">
+<link rel="stylesheet" href="{{ site.baseurl }}/static/css/style.css">
+<script src="{{ site.baseurl }}/static/js/jquery.min.js"></script>
+<script src="{{ site.baseurl }}/static/js/bootstrap.min.js"></script>
+<script src="{{ site.baseurl }}/static/js/bootstrap-select.min.js"></script>
 {% unless page.legacy %}
-<script src="/static/js/vue.min.js"></script>
-<script src="/static/js/timeago.min.js"></script>
+<script src="{{ site.baseurl }}/static/js/vue.min.js"></script>
+<script src="{{ site.baseurl }}/static/js/timeago.min.js"></script>
 {% endunless %}
-<script src="/static/js/markup.min.js"></script>
-<script src="/static/js/webfont.js"></script>
-<script src="/static/js/thuhidden.js"></script>
+<script src="{{ site.baseurl }}/static/js/markup.min.js"></script>
+<script src="{{ site.baseurl }}/static/js/webfont.js"></script>
+<script src="{{ site.baseurl }}/static/js/thuhidden.js"></script>
 {% if page.legacy %}
 <style>
 .container {

--- a/_layouts/help.html
+++ b/_layouts/help.html
@@ -52,7 +52,7 @@
 	{% include footer.html %}
 </body>
 
-<script src="/static/js/help.js"></script>
+<script src="{{ site.baseurl }}/static/js/help.js"></script>
 
 </html>
 <!--

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -16,8 +16,8 @@
 							<h1>{{ site.school }}开源软件镜像站</h1>
 							<h3>暂时无法提供服务</h3>
 							<div class="pull-right">
-								<img src="/static/img/candle.jpg" 
-									srcset="/static/img/candle.jpg 1x,
+								<img src="{{ site.baseurl }}/static/img/candle.jpg" 
+									srcset="{{ site.baseurl }}/static/img/candle.jpg 1x,
 													/static/img/candle@2x.jpg 2x"
 								/>
 							</div>
@@ -209,8 +209,8 @@
 	{% raw %}
 	{% endraw %}
 	{% unless page.legacy or site.issue %}
-	<script src="/static/js/index.js"></script>
-	<script src="/static/js/browser-update.js"></script>
+	<script src="{{ site.baseurl }}/static/js/index.js"></script>
+	<script src="{{ site.baseurl }}/static/js/browser-update.js"></script>
 	{% endunless %}
 </html>
 <!--

--- a/fancy-index/after.html
+++ b/fancy-index/after.html
@@ -13,8 +13,8 @@ permalink: /fancy-index/after.html
 	</body>
 	{% raw %}
 	{% endraw %}
-	<script src="/static/js/index.js"></script>
-	<script src="/static/js/browser-update.js"></script>
+	<script src="{{ site.baseurl }}/static/js/index.js"></script>
+	<script src="{{ site.baseurl }}/static/js/browser-update.js"></script>
 	{% raw %}
 	<script>
 		document.getElementById("list").setAttribute("class", "table");

--- a/status.html
+++ b/status.html
@@ -144,8 +144,8 @@ permalink: /status/
 		{% endunless %}
 	</div><!--/status -->
 	{% include footer.html %}
-	<script src="/static/js/status.js"></script>
-	<script src="/static/js/index.js"></script>
+	<script src="{{ site.baseurl }}/static/js/status.js"></script>
+	<script src="{{ site.baseurl }}/static/js/index.js"></script>
 </body>
 </html>
 <!--


### PR DESCRIPTION
Reference to static files were absolute and did not support Jekyll's
`baseurl` parametre, which, if the website is deployed with a url that is
not root (e.g. `mirrors.tuna.tsinghua.edu.cn/mirrors`), a 404 will be
returned when fetching static files as they are not correctly
referenced, causing the website to display that javascript was not
supported by the browser.
对静态文件的引用是绝对的（默认其在根目录下），并且不支持Jekyll的 `baseurl` 参数。这样一来，如果网站被部署在非根目录下（比如`mirrors.tuna.tsinghua.edu.cn/mirrors`），由于静态文件没有被正确引用，在访问它们时会导致404，网站则因此会显示浏览器不支持JS。

To solve this issue, this Q&A is referenced:
我参考了这个论坛问答，
https://talk.jekyllrb.com/t/relative-url-and-baseurl/2051,
by changing
`href="/static/114514.js"` to `"{{ site.baseurl }}/static/114514.js"`
we can eliminate the problem.
如此修改可以解决这个问题。

Nevertheless, it should be noted that there may possibly be other
static references which this single commit did not cover.
不过，这个commit不一定修复了所有的静态引用(∮ ′⌒`)