### PR TITLE
Delete backports for debian jessie

### DIFF
--- a/help/_posts/1970-01-01-debian.md
+++ b/help/_posts/1970-01-01-debian.md
@@ -41,8 +41,10 @@ deb https://{%endraw%}{{ site.hostname }}{%raw%}/debian/ {{release_name}} main c
 # deb-src https://{%endraw%}{{ site.hostname }}{%raw%}/debian/ {{release_name}} main contrib non-free{{if release_name|notequals>sid}}
 deb https://{%endraw%}{{ site.hostname }}{%raw%}/debian/ {{release_name}}-updates main contrib non-free
 # deb-src https://{%endraw%}{{ site.hostname }}{%raw%}/debian/ {{release_name}}-updates main contrib non-free
+{{if release_name|notequals>jessie}}
 deb https://{%endraw%}{{ site.hostname }}{%raw%}/debian/ {{release_name}}-backports main contrib non-free
 # deb-src https://{%endraw%}{{ site.hostname }}{%raw%}/debian/ {{release_name}}-backports main contrib non-free
+{{/if}}
 deb https://{%endraw%}{{ site.hostname }}{%raw%}/debian-security {{release_name}}{{release_security}} main contrib non-free
 # deb-src https://{%endraw%}{{ site.hostname }}{%raw%}/debian-security {{release_name}}{{release_security}} main contrib non-free
 {{/if}}


### PR DESCRIPTION
经过实验，发现 jessie 的 sources.list 并没有 jessie-backports，如果使用时直接复制黏贴提供的命令会导致 HttpError404.

https://ftp.debian.org/debian/dists/

https://mirrors.tuna.tsinghua.edu.cn/debian/dists/

