### PR TITLE
Update help for openSUSE Leap 15.3

### DIFF
--- a/help/_posts/2021-03-11-opensuse.md
+++ b/help/_posts/2021-03-11-opensuse.md
@@ -15,7 +15,7 @@ openSUSE 默认使用 [MirrorBrain](https://zh.opensuse.org/MirrorBrain) 技术�
 
 由于使用 MirrorBrain 需要从位于德国的 openSUSE 主服务器上获取元信息，所以若在使用默认软件源时获取元信息较慢，可以使用 TUNA 镜像软件源替换默认软件源。
 
-### openSUSE Leap 15.0 或更新版本使用方法
+### openSUSE Leap 15.2 或更新版本使用方法
 
 禁用官方软件源
 
@@ -26,17 +26,20 @@ sudo zypper mr -da
 添加 TUNA 镜像源
 
 ```shell
-sudo zypper ar -fcg https://{{ site.hostname }}/opensuse/distribution/leap/\$releasever/repo/oss/ tuna-oss
-sudo zypper ar -fcg https://{{ site.hostname }}/opensuse/distribution/leap/\$releasever/repo/non-oss/ tuna-non-oss
-sudo zypper ar -fcg https://{{ site.hostname }}/opensuse/update/leap/\$releasever/oss/ tuna-update-oss
-sudo zypper ar -fcg https://{{ site.hostname }}/opensuse/update/leap/\$releasever/non-oss/ tuna-update-non-oss
+sudo zypper ar -cfg 'https://{{ site.hostname }}/opensuse/distribution/leap/$releasever/repo/oss/' tuna-oss
+sudo zypper ar -cfg 'https://{{ site.hostname }}/opensuse/distribution/leap/$releasever/repo/non-oss/' tuna-non-oss
+sudo zypper ar -cfg 'https://{{ site.hostname }}/opensuse/update/leap/$releasever/oss/' tuna-update
+sudo zypper ar -cfg 'https://{{ site.hostname }}/opensuse/update/leap/$releasever/non-oss/' tuna-update-non-oss
 ```
 
-刷新软件源
+Leap 15.3 用户还需添加 sle 和 backports 源
 
 ```shell
-sudo zypper ref
+sudo zypper ar -cfg 'https://{{ site.hostname }}/opensuse/update/leap/$releasever/sle/' tuna-sle-update
+sudo zypper ar -cfg 'https://{{ site.hostname }}/opensuse/update/leap/$releasever/backports/' tuna-backports-update
 ```
+
+Leap 15.3 注：若在安装时**没有**启用在线软件源， sle 源和 backports 源将在系统首次更新后引入，请确保系统在更新后仅启用了**六个**所需软件源。可使用 `zypper lr` 检查软件源状态，并使用 `zypper mr -d` 禁用多余的软件源。
 
 ### openSUSE Tumbleweed 使用方法
 
@@ -49,8 +52,8 @@ sudo zypper mr -da
 添加 TUNA 镜像源
 
 ```shell
-sudo zypper ar -fcg https://{{ site.hostname }}/opensuse/tumbleweed/repo/oss/ tuna-oss
-sudo zypper ar -fcg https://{{ site.hostname }}/opensuse/tumbleweed/repo/non-oss/ tuna-non-oss
+sudo zypper ar -cfg 'https://{{ site.hostname }}/opensuse/tumbleweed/repo/oss/' tuna-oss
+sudo zypper ar -cfg 'https://{{ site.hostname }}/opensuse/tumbleweed/repo/non-oss/' tuna-non-oss
 ```
 
 刷新软件源


### PR DESCRIPTION
upstream now fix the missing content in backports repo, that fixed https://github.com/tuna/issues/issues/1269
including a note for 15.3 users to ensure correct repo enabled
version before 15.2 have officially EOL, so bump version
minor change to repo alias, make it match the official naming
also minor tweak to command style