### PR TITLE
GenISOList: Add more Fedora ISO images.

### DIFF
--- a/geninfo/genisolist.ini
+++ b/geninfo/genisolist.ini
@@ -248,15 +248,49 @@ version = $1
 type = $3
 platform = $2
 
-[fedora]
+[fedora_workstation]
 distro = Fedora
 listvers = 2
 location_0 = fedora/releases/[1-9][0-9]/Workstation/*/iso/Fedora-Workstation-Live-*-[1-9][0-9]-*.iso
-location_1 = fedora/releases/[1-9][0-9]/Spins/*/iso/Fedora-KDE-Live-*-[1-9][0-9]-*.iso
-location_2 = fedora/releases/[1-9][0-9]/Spins/*/iso/Fedora-Xfce-Live-*-[1-9][0-9]-*.iso
-pattern = Fedora-(Workstation|KDE|Xfce)-Live-(\w+)-(\d+)-.*\.iso
+pattern = Fedora-Workstation-Live-(\w+)-(\d+)-.*\.iso
+version = $2
+type = Live CD with standard workstation desktop environment
+platform = $1
+
+[fedora_spins]
+distro = Fedora
+listvers = 2
+location_0 = fedora/releases/[1-9][0-9]/Spins/*/iso/Fedora-*-Live-*-[1-9][0-9]-*.iso
+pattern = Fedora-(\w+)-Live-(\w+)-(\d+)-.*\.iso
 version = $3
-type = $1
+type = Live CD with $1
+platform = $2
+
+[fedora_server]
+distro = Fedora
+listvers = 2
+location_0 = fedora/releases/[1-9][0-9]/Server/*/iso/Fedora-Server-*-[1-9][0-9]-*.iso
+pattern = Fedora-Server-(\w+)-(\w+)-(\d+)-.*\.iso
+version = $3
+type = Server $1
+platform = $2
+
+[fedora_silverblue]
+distro = Fedora
+listvers = 2
+location_0 = fedora/releases/[1-9][0-9]/Silverblue/*/iso/Fedora-Silverblue-*-[1-9][0-9]-*.iso
+pattern = Fedora-Silverblue-(\w+)-(\w+)-(\d+)-.*\.iso
+version = $3
+type = Silverblue $1
+platform = $2
+
+[fedora_everything]
+distro = Fedora
+listvers = 2
+location_0 = fedora/releases/[1-9][0-9]/Everything/*/iso/Fedora-Everything-*-[1-9][0-9]-*.iso
+pattern = Fedora-Everything-(\w+)-(\w+)-(\d+)-.*\.iso
+version = $3
+type = Everything $1
 platform = $2
 
 [opensuse_leap]


### PR DESCRIPTION
This PR adds more Fedora ISO images to the image download list.
JSON manifest generated by the script will be something like this:
```json
[
  {
    "distro": "Fedora",
    "category": "os",
    "urls": [
      {
        "name": "34 (x86_64, Everything netinst)",
        "url": "/fedora/releases/34/Everything/x86_64/iso/Fedora-Everything-netinst-x86_64-34-1.2.iso"
      },
      {
        "name": "34 (x86_64, Live CD with LXDE)",
        "url": "/fedora/releases/34/Spins/x86_64/iso/Fedora-LXDE-Live-x86_64-34-1.2.iso"
      },
      {
        "name": "34 (x86_64, Live CD with LXQt)",
        "url": "/fedora/releases/34/Spins/x86_64/iso/Fedora-LXQt-Live-x86_64-34-1.2.iso"
      },
      {
        "name": "34 (x86_64, Live CD with i3)",
        "url": "/fedora/releases/34/Spins/x86_64/iso/Fedora-i3-Live-x86_64-34-1.2.iso"
      },
      {
        "name": "34 (x86_64, Live CD with standard workstation desktop environment)",
        "url": "/fedora/releases/34/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-34-1.2.iso"
      },
      {
        "name": "34 (x86_64, Server dvd)",
        "url": "/fedora/releases/34/Server/x86_64/iso/Fedora-Server-dvd-x86_64-34-1.2.iso"
      },
      {
        "name": "34 (x86_64, Server netinst)",
        "url": "/fedora/releases/34/Server/x86_64/iso/Fedora-Server-netinst-x86_64-34-1.2.iso"
      },
      {
        "name": "34 (x86_64, Silverblue ostree)",
        "url": "/fedora/releases/34/Silverblue/x86_64/iso/Fedora-Silverblue-ostree-x86_64-34-1.2.iso"
      }
    ]
  }
]

```