### PR TITLE
add homebrew/command-not-found to auto tap script

### DIFF
--- a/help/_posts/1970-01-01-homebrew.md
+++ b/help/_posts/1970-01-01-homebrew.md
@@ -83,7 +83,7 @@ git -C "$(brew --repo homebrew/command-not-found)" remote set-url origin https:/
 
 # 或使用下面的几行命令自动设置
 BREW_TAPS="$(brew tap)"
-for tap in core cask{,-fonts,-drivers,-versions,} command-not-found; do
+for tap in core cask{,-fonts,-drivers,-versions} command-not-found; do
     if echo "$BREW_TAPS" | grep -qE "^homebrew/${tap}\$"; then
         # 将已有 tap 的上游设置为本镜像并设置 auto update
         # 注：原 auto update 只针对托管在 GitHub 上的上游有效

--- a/help/_posts/1970-01-01-homebrew.md
+++ b/help/_posts/1970-01-01-homebrew.md
@@ -83,7 +83,7 @@ git -C "$(brew --repo homebrew/command-not-found)" remote set-url origin https:/
 
 # 或使用下面的几行命令自动设置
 BREW_TAPS="$(brew tap)"
-for tap in core cask{,-fonts,-drivers,-versions}; do
+for tap in core cask{,-fonts,-drivers,-versions,} command-not-found; do
     if echo "$BREW_TAPS" | grep -qE "^homebrew/${tap}\$"; then
         # 将已有 tap 的上游设置为本镜像并设置 auto update
         # 注：原 auto update 只针对托管在 GitHub 上的上游有效
@@ -117,7 +117,7 @@ git -C "$(brew --repo)" remote set-url origin https://github.com/Homebrew/brew.g
 
 # 以下针对 macOS 系统上的 Homebrew
 BREW_TAPS="$(brew tap)"
-for tap in core cask{,-fonts,-drivers,-versions}; do
+for tap in core cask{,-fonts,-drivers,-versions} command-not-found; do
     if echo "$BREW_TAPS" | grep -qE "^homebrew/${tap}\$"; then
         git -C "$(brew --repo homebrew/${tap})" remote set-url origin https://github.com/Homebrew/homebrew-${tap}.git
     fi


### PR DESCRIPTION
Good morning TUNA maintainers,

For macOS Homebrew users,
```shell
git -C "$(brew --repo homebrew/command-not-found)" remote set-url origin https://mirrors.tuna.tsinghua.edu.cn/git/homebrew/homebrew-command-not-found.git
```
that `homebrew/command-not-found` is available in TUNA mirror upstream, however is not updated in the auto-setup script.

This PR added the `homebrew/command-not-found` to the auto-setup script, both the replace and reset, to enable the manual replace and reset work.

