### PR TITLE
Re-Add wireshark in frontend

### DIFF
--- a/geninfo/genisolist.ini
+++ b/geninfo/genisolist.ini
@@ -1004,6 +1004,33 @@ version = $1
 platform = $2
 type = iso
 
+[wireshark win]
+distro = Wireshark
+location = wireshark/*/*
+pattern = Wireshark-([^/]+)-([\.\d]+)\.(exe|msi)
+version = $2
+platform = $1
+type = $3
+category = app
+
+[wireshark portable]
+distro = Wireshark
+location = wireshark/*/*
+pattern = WiresharkPortable_([\.\d]+)\.(paf\.exe)
+version = Portable $1
+platform = win
+type = $2
+category = app
+
+[wireshark osx]
+distro = Wireshark
+location = wireshark/osx/*.dmg
+pattern = Wireshark ([\.\d]+) ([^/]+)\.dmg
+version = $1
+platform = $2
+type = dmg
+category = app
+
 [cmder]
 distro = cmder
 location = github-release/cmderdev/cmder/LatestRelease/*


### PR DESCRIPTION
镜像站首页之前在 e081e35968383bca92ddcf6c06213bd1b05565f0 提交中增加了 Wireshark 前端链接。
但由于 https://github.com/tuna/issues/issues/1160 反馈以及 Wireshark 已不在此站发布新版软件的软件包，因此在 e93aa3bd2140ae4d4b1f6228e0a6ff1a144e8704 取消了 Wireshark 前端链接。
考虑到在 https://github.com/tuna/issues/issues/1164 已经完成了对 Wireshark 官方镜像的添加，因此本 PR 中恢复了镜像站首页的 Wireshark 前端链接，便于中国大陆用户快速、安全的下载 Wireshark 系列软件。