### PR TITLE
Update docs for Homebrew

### DIFF
--- a/help/_posts/1970-01-01-homebrew.md
+++ b/help/_posts/1970-01-01-homebrew.md
@@ -23,6 +23,7 @@ mirrorid: homebrew
 if [[ "$(uname -s)" == "Linux" ]]; then BREW_TYPE="linuxbrew"; else BREW_TYPE="homebrew"; fi
 export HOMEBREW_BREW_GIT_REMOTE="https://{{ site.hostname }}/git/homebrew/brew.git"
 export HOMEBREW_CORE_GIT_REMOTE="https://{{ site.hostname }}/git/homebrew/${BREW_TYPE}-core.git"
+export HOMEBREW_BOTTLE_DOMAIN="https://{{ site.hostname }}/${BREW_TYPE}-bottles"
 ```
 
 最后，在终端运行以下命令以安装 Homebrew / Linuxbrew：
@@ -82,15 +83,15 @@ git -C "$(brew --repo homebrew/cask-versions)" remote set-url origin https://{{ 
 git -C "$(brew --repo homebrew/command-not-found)" remote set-url origin https://{{ site.hostname }}/git/homebrew/homebrew-command-not-found.git
 
 # 或使用下面的几行命令自动设置
-BREW_TAPS="$(brew tap)"
+BREW_TAPS="$(BREW_TAPS="$(brew tap 2>/dev/null)"; echo -n "${BREW_TAPS//$'\n'/:}")"
 for tap in core cask{,-fonts,-drivers,-versions} command-not-found; do
-    if echo "$BREW_TAPS" | grep -qE "^homebrew/${tap}\$"; then
+    if [[ ":${BREW_TAPS}:" == *":homebrew/${tap}:"* ]]; then
         # 将已有 tap 的上游设置为本镜像并设置 auto update
         # 注：原 auto update 只针对托管在 GitHub 上的上游有效
-        git -C "$(brew --repo homebrew/${tap})" remote set-url origin https://{{ site.hostname }}/git/homebrew/homebrew-${tap}.git
+        git -C "$(brew --repo homebrew/${tap})" remote set-url origin "https://{{ site.hostname }}/git/homebrew/homebrew-${tap}.git"
         git -C "$(brew --repo homebrew/${tap})" config homebrew.forceautoupdate true
     else   # 在 tap 缺失时自动安装（如不需要请删除此行和下面一行）
-        brew tap --force-auto-update homebrew/${tap} https://{{ site.hostname }}/git/homebrew/homebrew-${tap}.git
+        brew tap --force-auto-update "homebrew/${tap}" "https://{{ site.hostname }}/git/homebrew/homebrew-${tap}.git"
     fi
 done
 ```
@@ -99,6 +100,7 @@ done
 
 ```bash
 git -C "$(brew --repo homebrew/core)" remote set-url origin https://{{ site.hostname }}/git/homebrew/linuxbrew-core.git
+git -C "$(brew --repo homebrew/command-not-found)" remote set-url origin https://{{ site.hostname }}/git/homebrew/homebrew-command-not-found.git
 ```
 
 更换上游后需重新设置 git 仓库 HEAD：
@@ -116,15 +118,16 @@ _(感谢 Snowonion Lee 提供说明)_
 git -C "$(brew --repo)" remote set-url origin https://github.com/Homebrew/brew.git
 
 # 以下针对 macOS 系统上的 Homebrew
-BREW_TAPS="$(brew tap)"
+BREW_TAPS="$(BREW_TAPS="$(brew tap 2>/dev/null)"; echo -n "${BREW_TAPS//$'\n'/:}")"
 for tap in core cask{,-fonts,-drivers,-versions} command-not-found; do
-    if echo "$BREW_TAPS" | grep -qE "^homebrew/${tap}\$"; then
-        git -C "$(brew --repo homebrew/${tap})" remote set-url origin https://github.com/Homebrew/homebrew-${tap}.git
+    if [[ ":${BREW_TAPS}:" == *":homebrew/${tap}:"* ]]; then
+        git -C "$(brew --repo homebrew/${tap})" remote set-url origin "https://github.com/Homebrew/homebrew-${tap}.git"
     fi
 done
 
 # 以下针对 Linux 系统上的 Linuxbrew
 git -C "$(brew --repo homebrew/core)" remote set-url origin https://github.com/Homebrew/linuxbrew-core.git
+git -C "$(brew --repo homebrew/command-not-found)" remote set-url origin https://github.com/Homebrew/homebrew-command-not-found.git
 
 # 重新设置 git 仓库 HEAD
 brew update-reset


### PR DESCRIPTION
1. 重新在首次安装 Homebrew / Linuxbrew 时即使用 bottle 镜像。
2. 更新检查 tap 是否存在条件：将 `grep` 改为 `bash` 自带的字符串匹配。
3. 添加 Homebrew/command-not-found 在 Linux 上的帮助。
4. 带变量的字符串添加双引号。