### PR TITLE
Update docs for Homebrew

### DIFF
--- a/help/_posts/1970-01-01-homebrew.md
+++ b/help/_posts/1970-01-01-homebrew.md
@@ -68,46 +68,41 @@ _* 安装成功后需将 brew 程序的相关路径加入到环境变量中：_
 替换 brew 程序本身的源，Homebrew / Linuxbrew 相同：
 
 ```bash
-git -C "$(brew --repo)" remote set-url origin https://{{ site.hostname }}/git/homebrew/brew.git
+export HOMEBREW_BREW_GIT_REMOTE="https://{{ site.hostname }}/git/homebrew/brew.git"
+brew update
 ```
 
 以下针对 macOS 系统上的 Homebrew：
 
 ```bash
 # 手动设置
-git -C "$(brew --repo homebrew/core)" remote set-url origin https://{{ site.hostname }}/git/homebrew/homebrew-core.git
-git -C "$(brew --repo homebrew/cask)" remote set-url origin https://{{ site.hostname }}/git/homebrew/homebrew-cask.git
-git -C "$(brew --repo homebrew/cask-fonts)" remote set-url origin https://{{ site.hostname }}/git/homebrew/homebrew-cask-fonts.git
-git -C "$(brew --repo homebrew/cask-drivers)" remote set-url origin https://{{ site.hostname }}/git/homebrew/homebrew-cask-drivers.git
-git -C "$(brew --repo homebrew/cask-versions)" remote set-url origin https://{{ site.hostname }}/git/homebrew/homebrew-cask-versions.git
-git -C "$(brew --repo homebrew/command-not-found)" remote set-url origin https://{{ site.hostname }}/git/homebrew/homebrew-command-not-found.git
+export HOMEBREW_CORE_GIT_REMOTE="https://{{ site.hostname }}/git/homebrew/homebrew-core.git"
+brew tap --custom-remote --force-auto-update homebrew/core https://{{ site.hostname }}/git/homebrew/homebrew-core.git
+brew tap --custom-remote --force-auto-update homebrew/cask https://{{ site.hostname }}/git/homebrew/homebrew-cask.git
+brew tap --custom-remote --force-auto-update homebrew/cask-fonts https://{{ site.hostname }}/git/homebrew/homebrew-cask-fonts.git
+brew tap --custom-remote --force-auto-update homebrew/cask-drivers https://{{ site.hostname }}/git/homebrew/homebrew-cask-drivers.git
+brew tap --custom-remote --force-auto-update homebrew/cask-versions https://{{ site.hostname }}/git/homebrew/homebrew-cask-versions.git
+brew tap --custom-remote --force-auto-update homebrew/command-not-found https://{{ site.hostname }}/git/homebrew/homebrew-command-not-found.git
+brew update
 
 # 或使用下面的几行命令自动设置
-BREW_TAPS="$(BREW_TAPS="$(brew tap 2>/dev/null)"; echo -n "${BREW_TAPS//$'\n'/:}")"
+export HOMEBREW_CORE_GIT_REMOTE="https://{{ site.hostname }}/git/homebrew/linuxbrew-core.git"
 for tap in core cask{,-fonts,-drivers,-versions} command-not-found; do
-    if [[ ":${BREW_TAPS}:" == *":homebrew/${tap}:"* ]]; then
-        # 将已有 tap 的上游设置为本镜像并设置 auto update
-        # 注：原 auto update 只针对托管在 GitHub 上的上游有效
-        git -C "$(brew --repo homebrew/${tap})" remote set-url origin "https://{{ site.hostname }}/git/homebrew/homebrew-${tap}.git"
-        git -C "$(brew --repo homebrew/${tap})" config homebrew.forceautoupdate true
-    else   # 在 tap 缺失时自动安装（如不需要请删除此行和下面一行）
-        brew tap --force-auto-update "homebrew/${tap}" "https://{{ site.hostname }}/git/homebrew/homebrew-${tap}.git"
-    fi
+    brew tap --custom-remote --force-auto-update "homebrew/${tap}" "https://{{ site.hostname }}/git/homebrew/homebrew-${tap}.git"
 done
+brew update
 ```
 
 以下针对 Linux 系统上的 Linuxbrew：
 
 ```bash
-git -C "$(brew --repo homebrew/core)" remote set-url origin https://{{ site.hostname }}/git/homebrew/linuxbrew-core.git
-git -C "$(brew --repo homebrew/command-not-found)" remote set-url origin https://{{ site.hostname }}/git/homebrew/homebrew-command-not-found.git
+export HOMEBREW_CORE_GIT_REMOTE="https://{{ site.hostname }}/git/homebrew/linuxbrew-core.git"
+brew tap --custom-remote --force-auto-update homebrew/core https://{{ site.hostname }}/git/homebrew/linuxbrew-core.git
+brew tap --custom-remote --force-auto-update homebrew/command-not-found https://{{ site.hostname }}/git/homebrew/homebrew-command-not-found.git
+brew update
 ```
 
-更换上游后需重新设置 git 仓库 HEAD：
-
-```bash
-brew update-reset
-```
+**注：如果用户设置了环境变量 `HOMEBREW_BREW_GIT_REMOTE` 和 `HOMEBREW_CORE_GIT_REMOTE`，则每次执行 `brew update` 时，`brew` 程序本身和 Core Tap (`homebrew-core` 或 `linuxbrew-core`) 的远程将被自动设置。推荐用户将这两个环境变量设置加入 shell 的 profile 设置中。**
 
 ### 复原仓库上游
 
@@ -115,20 +110,25 @@ _(感谢 Snowonion Lee 提供说明)_
 
 ```bash
 # brew 程序本身，Homebrew / Linuxbrew 相同
-git -C "$(brew --repo)" remote set-url origin https://github.com/Homebrew/brew.git
+unset HOMEBREW_BREW_GIT_REMOTE
+git -C "$(brew --repo)" remote set-url origin https://github.com/Homebrew/brew
 
 # 以下针对 macOS 系统上的 Homebrew
+unset HOMEBREW_CORE_GIT_REMOTE
 BREW_TAPS="$(BREW_TAPS="$(brew tap 2>/dev/null)"; echo -n "${BREW_TAPS//$'\n'/:}")"
 for tap in core cask{,-fonts,-drivers,-versions} command-not-found; do
-    if [[ ":${BREW_TAPS}:" == *":homebrew/${tap}:"* ]]; then
-        git -C "$(brew --repo homebrew/${tap})" remote set-url origin "https://github.com/Homebrew/homebrew-${tap}.git"
+    if [[ ":${BREW_TAPS}:" == *":homebrew/${tap}:"* ]]; then  # 只复原已安装的 Tap
+        brew tap --custom-remote "homebrew/${tap}" "https://github.com/Homebrew/homebrew-${tap}"
     fi
 done
 
 # 以下针对 Linux 系统上的 Linuxbrew
-git -C "$(brew --repo homebrew/core)" remote set-url origin https://github.com/Homebrew/linuxbrew-core.git
-git -C "$(brew --repo homebrew/command-not-found)" remote set-url origin https://github.com/Homebrew/homebrew-command-not-found.git
+unset HOMEBREW_CORE_GIT_REMOTE
+brew tap --custom-remote homebrew/core https://github.com/Homebrew/linuxbrew-core
+brew tap --custom-remote homebrew/command-not-found https://github.com/Homebrew/homebrew-command-not-found
 
-# 重新设置 git 仓库 HEAD
-brew update-reset
+# 重新拉取远程
+brew update
 ```
+
+**注：重置回默认远程后，用户应该删除 shell 的 profile 设置中的环境变量 `HOMEBREW_BREW_GIT_REMOTE` 和 `HOMEBREW_CORE_GIT_REMOTE` 以免运行 `brew update` 时远程再次被更换。**


### PR DESCRIPTION
Update docs for Homebrew.

- Add docs for environment variables `HOMEBREW_BREW_GIT_REMOTE` and `HOMEBREW_CORE_GIT_REMOTE`.
- Change mirroring command from `git -C "$(brew --repo ...)" remote set-url origin ...` to `brew tap --custom-remote ... ...`. (introduced in Homebrew/brew#12221)