### PR TITLE
修正 KiCad 网址

### DIFF
--- a/help/_posts/2019-07-23-kicad.md
+++ b/help/_posts/2019-07-23-kicad.md
@@ -6,7 +6,7 @@ mirrorid: kicad
 
 ## KiCad 镜像使用帮助
 
-[KiCad](http://kicad-pcb.org/) 一个跨平台的开源电子设计自动化套件。 
+[KiCad](http://kicad.org/) 一个跨平台的开源电子设计自动化套件。 
 
 ### KiCad 镜像目录使用说明
 


### PR DESCRIPTION
详细说明查看 KiCad 社区官网  https://www.kicad.org/blog/2021/10/Avoid-links-to-former-kicad-domain/