### PR TITLE
Update 1970-01-01-centos.md

### DIFF
--- a/help/_posts/1970-01-01-centos.md
+++ b/help/_posts/1970-01-01-centos.md
@@ -8,7 +8,7 @@ mirrorid: centos
 
 该文件夹只提供 CentOS 7 与 8，架构仅为 `x86_64` ，如果需要较早版本的 CentOS，请参考 centos-vault 的帮助，若需要其他架构，请参考 centos-altarch 的帮助。
 
-建议先备份 `/etc/yum.repos.d/` 内的文件（CentOS 7 及之前为 `CentOS-Base.repo`，CentOS 8 为`CentOS-Linux-*.repo`）
+建议先备份 `/etc/yum.repos.d/` 内的文件。
 
 然后编辑 `/etc/yum.repos.d/` 中的相应文件，在 `mirrorlist=` 开头行前面加 `#` 注释掉；并将 `baseurl=` 开头行取消注释（如果被注释的话），把该行内的域名（例如`mirror.centos.org`）替换为 `{{ site.hostname }}`。
 


### PR DESCRIPTION
对于`CentOS 8`，小版本不同的系统下`/etc/yum.repos.d/`目录中的文件名是不同的。
```
[root@localhost ~]# cat /etc/centos-release
CentOS Linux release 8.0.1905 (Core)
[root@localhost ~]# ls /etc/yum.repos.d/
CentOS-AppStream.repo   CentOS-Debuginfo.repo  CentOS-PowerTools.repo  epel-playground.repo
CentOS-Base.repo        CentOS-Extras.repo     CentOS-Sources.repo     epel.repo
CentOS-centosplus.repo  CentOS-fasttrack.repo  CentOS-Vault.repo       epel-testing-modular.repo
CentOS-CR.repo          CentOS-Media.repo      epel-modular.repo       epel-testing.repo
[root@localhost ~]#
```