### PR TITLE
Update ROS2 Document

### DIFF
--- a/help/_posts/1970-01-01-ros2.md
+++ b/help/_posts/1970-01-01-ros2.md
@@ -6,8 +6,15 @@ mirrorid: ros2
 
 ## ROS2 镜像使用帮助
 
+输入如下命令，下载 ROS 的 GPG Key：
 
-新建 `/etc/apt/sources.list.d/ros2-latest.list`，内容为：
+```
+sudo apt install curl gnupg2
+sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
+```
+
+
+再输入如下命令，添加软件仓库，并更新索引：
 
 <form class="form-inline">
 <div class="form-group">
@@ -31,16 +38,10 @@ mirrorid: ros2
 
 {% raw %}
 <script id="apt-template" type="x-tmpl-markup">
-deb https://{%endraw%}{{ site.hostname }}{%raw%}/ros2/ubuntu/ {{release_name}} main
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] https://{%endraw%}{{ site.hostname }}{%raw%}/ros2/ubuntu {{release_name}} main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+
+sudo apt update
 </script>
 {%endraw%}
 
-然后再输入如下命令，信任 ROS 的 GPG Key，并更新索引：
-
-```
-sudo apt install curl gnupg2
-curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
-sudo apt update
-```
-
-Reference: https://index.ros.org/doc/ros2/Installation/Crystal/Linux-Install-Binary/
+Reference: https://docs.ros.org/en/foxy/Installation/Ubuntu-Install-Debians.html


### PR DESCRIPTION
ROS2 没有 i386 的版本，原来的版本不指定 arch，会导致 apt update 的时候出现 404 错误，  
因此加入了 `[arch=$(dpkg --print-architecture)]` 这一项，和官方文档同步。  


另外，根据较新的[官方文档](https://docs.ros.org/en/foxy/Installation/Ubuntu-Install-Debians.html)，已经不再使用 `apt-key` 了，所以这里也进行了相应的改动。（另请参考 tuna/issues#1413）
