### PR TITLE
Update 1970-01-01-gitlab-ce.md

### DIFF
--- a/help/_posts/1970-01-01-gitlab-ce.md
+++ b/help/_posts/1970-01-01-gitlab-ce.md
@@ -24,10 +24,11 @@ curl https://packages.gitlab.com/gpg.key 2> /dev/null | sudo apt-key add - &>/de
 	<select class="form-control release-select" data-template="#apt-template" data-target="#apt-content">
 		<option data-os="debian" data-release="jessie">Debian 8 (Jessie)</option>
 		<option data-os="debian" data-release="stretch">Debian 9 (Stretch)</option>
-		<option data-os="debian" data-release="buster" selected>Debian 10 (Buster)</option>
-		<option data-os="ubuntu" data-release="trusty">Ubuntu 14.04 LTS</option>
+		<option data-os="debian" data-release="buster">Debian 10 (Buster)</option>
+		<option data-os="debian" data-release="bullseye" selected>Debian 11 (Bullseye)</option>
 		<option data-os="ubuntu" data-release="xenial">Ubuntu 16.04 LTS</option>
 		<option data-os="ubuntu" data-release="bionic">Ubuntu 18.04 LTS</option>
+		<option data-os="ubuntu" data-release="focal">Ubuntu 20.04 LTS</option>
 </select>
 </div>
 </form>


### PR DESCRIPTION
Add ubuntu 20.24 and Debian 11, delete ubuntu 14.04(already deleted from https://mirrors.bfsu.edu.cn/gitlab-ce/ubuntu/)