### PR TITLE
升级pip自身，需要分不同平台执行不同的命令

### DIFF
--- a/help/_posts/1970-01-01-pypi.md
+++ b/help/_posts/1970-01-01-pypi.md
@@ -26,7 +26,14 @@ pip config set global.index-url https://{{ site.pypi }}/simple
 ```
 
 如果您到 pip 默认源的网络连接较差，临时使用本镜像站来升级 pip：
+### windows 平台
 
 ```
-pip install -i https://{{ site.pypi }}/simple pip -U
+python -m pip install -i https://{{ site.pypi }}/simple pip -U
 ```
+### Linux 或 macOS 平台
+
+```
+pip install -i https://{{ site.pypi }}/simple --upgrade pip
+```
+

--- a/help/_posts/1970-01-01-pypi.md
+++ b/help/_posts/1970-01-01-pypi.md
@@ -26,12 +26,12 @@ pip config set global.index-url https://{{ site.pypi }}/simple
 ```
 
 如果您到 pip 默认源的网络连接较差，临时使用本镜像站来升级 pip：
-### windows 平台
+windows 平台：
 
 ```
 python -m pip install -i https://{{ site.pypi }}/simple pip -U
 ```
-### Linux 或 macOS 平台
+Linux 或 macOS 平台：
 
 ```
 pip install -i https://{{ site.pypi }}/simple --upgrade pip


### PR DESCRIPTION
在Windows平台上，必须使用python -m pip这种方式