### PR TITLE
genisoinfo: improve vscodium win

### DIFF
--- a/geninfo/genisolist.ini
+++ b/geninfo/genisolist.ini
@@ -705,11 +705,11 @@ category = app
 distro = VS Codium
 listvers = 10
 location = github-release/VSCodium/vscodium/LatestRelease/*
-pattern = (VSCodium\w+-\w+)-([\.\d]+)\.exe(?!.)
+pattern = (VSCodium(?!-darwin)[\w-]+)-([\.\d]+)\.(exe|msi|zip)(?!.)
 platform = Windows
-type = $1
+type = $1 $3
 version = $2
-sort_by = Windows $1 $2
+sort_by = Windows $1 $3 $2
 category = app
 
 [vscodium linux tar]


### PR DESCRIPTION
Will exclude `VSCodium-darwin*`, then match `VSCodium*.exe`, `VSCodium*.msi` and `VSCodium*.zip`.