### PR TITLE
help: add debian bullseye and ubuntu jammy

### DIFF
--- a/help/_posts/1970-01-01-gitlab-runner.md
+++ b/help/_posts/1970-01-01-gitlab-runner.md
@@ -24,9 +24,11 @@ curl https://packages.gitlab.com/gpg.key 2> /dev/null | sudo apt-key add - &>/de
 	<select class="form-control release-select" data-template="#apt-template" data-target="#apt-content">
 		<option data-os="debian" data-release="jessie">Debian 8 (Jessie)</option>
 		<option data-os="debian" data-release="stretch">Debian 9 (Stretch)</option>
-		<option data-os="debian" data-release="buster" selected>Debian 10 (Buster)</option>
+		<option data-os="debian" data-release="buster">Debian 10 (Buster)</option>
+		<option data-os="debian" data-release="bullseye" selected>Debian 11 (Bullseye)</option>
 		<option data-os="ubuntu" data-release="xenial">Ubuntu 16.04 LTS</option>
-		<option data-os="ubuntu" data-release="bionic">Ubuntu 18.04 LTS</option>		
+		<option data-os="ubuntu" data-release="bionic">Ubuntu 18.04 LTS</option>
+		<option data-os="ubuntu" data-release="focal">Ubuntu 20.04 LTS</option>
 	</select>
 </div>
 </form>

--- a/help/_posts/1970-01-01-ros2.md
+++ b/help/_posts/1970-01-01-ros2.md
@@ -13,10 +13,13 @@ mirrorid: ros2
 <div class="form-group">
 	<label>你的Debian/Ubuntu版本: </label>
 	<select class="form-control release-select" data-template="#apt-template" data-target="#apt-content">
+		<option data-os="debian" data-release="jessie">Debian 8 (Jessie)</option>
 		<option data-os="debian" data-release="stretch">Debian 9 (Stretch)</option>
 		<option data-os="debian" data-release="buster">Debian 10 (Buster)</option>
+		<option data-os="debian" data-release="bullseye" selected>Debian 11 (Bullseye)</option>
+		<option data-os="ubuntu" data-release="trusty">Ubuntu 14.04 LTS</option>
 		<option data-os="ubuntu" data-release="xenial">Ubuntu 16.04 LTS</option>
-		<option data-os="ubuntu" data-release="bionic" selected>Ubuntu 18.04 LTS</option>		
+		<option data-os="ubuntu" data-release="bionic">Ubuntu 18.04 LTS</option>
 		<option data-os="ubuntu" data-release="focal">Ubuntu 20.04 LTS</option>
 </select>
 </div>

--- a/help/_posts/1970-01-01-ubuntu-ports.md
+++ b/help/_posts/1970-01-01-ubuntu-ports.md
@@ -16,13 +16,13 @@ TUNA 的软件源镜像。
 <div class="form-group">
 	<label>选择你的ubuntu版本: </label>
 	<select class="form-control release-select" data-template="#apt-template" data-target="#apt-content">
-	  <option data-release="precise">12.04 LTS</option>
-	  <option data-release="trusty">14.04 LTS</option>
-	  <option data-release="xenial">16.04 LTS</option>
-	  <option data-release="bionic">18.04 LTS</option>
-	  <option data-release="focal" selected>20.04 LTS</option>
-	  <option data-release="hirsute">21.04</option>
+		<option data-release="trusty">14.04 LTS</option>
+		<option data-release="xenial">16.04 LTS</option>
+		<option data-release="bionic">18.04 LTS</option>
+		<option data-release="focal">20.04 LTS</option>
+		<option data-release="hirsute">21.04</option>
 		<option data-release="impish">21.10</option>
+		<option data-release="jammy" selected>22.04 LTS</option>
 	</select>
 </div>
 </form>

--- a/help/_posts/1970-01-01-ubuntu.md
+++ b/help/_posts/1970-01-01-ubuntu.md
@@ -16,13 +16,13 @@ TUNA 的软件源镜像。
 <div class="form-group">
 	<label>选择你的ubuntu版本: </label>
 	<select class="form-control release-select" data-template="#apt-template" data-target="#apt-content">
-	  <option data-release="precise">12.04 LTS</option>
-	  <option data-release="trusty">14.04 LTS</option>
-	  <option data-release="xenial">16.04 LTS</option>
-	  <option data-release="bionic">18.04 LTS</option>
-	  <option data-release="focal" selected>20.04 LTS</option>
-	  <option data-release="hirsute">21.04</option>
-	  <option data-release="impish">21.10</option>
+		<option data-release="trusty">14.04 LTS</option>
+		<option data-release="xenial">16.04 LTS</option>
+		<option data-release="bionic">18.04 LTS</option>
+		<option data-release="focal">20.04 LTS</option>
+		<option data-release="hirsute">21.04</option>
+		<option data-release="impish">21.10</option>
+		<option data-release="jammy" selected>22.04 LTS</option>
 	</select>
 </div>
 </form>

--- a/help/_posts/2016-06-19-virtualbox.md
+++ b/help/_posts/2016-06-19-virtualbox.md
@@ -59,7 +59,8 @@ wget -q https://www.virtualbox.org/download/oracle_vbox.asc -O- | sudo apt-key a
 <div class="form-group">
   <label>你的Debian/Ubuntu版本: </label>
   <select class="form-control release-select" data-template="#apt-template" data-target="#apt-content">
-	  <option data-os="debian" data-release="buster" selected>Debian 10 (Buster)</option>
+	  <option data-os="debian" data-release="bullseye" selected>Debian 11 (Bullseye)</option>
+	  <option data-os="debian" data-release="buster">Debian 10 (Buster)</option>
     <option data-os="debian" data-release="stretch">Debian 9 (Stretch)</option>
     <option data-os="debian" data-release="jessie">Debian 8 (Jessie)</option>
 	  <option data-os="ubuntu" data-release="bionic">Ubuntu 18.04 LTS</option>


### PR DESCRIPTION
本来我想把 `#apt-template` 放到`_include` 里，各个 `help/_post/*.md` 只做引用；
结果发现每个软件仓库支持的系统版本会有细微差异，例如大多数项目还没发现 Ubuntu 22.04 LTS 发布了。

仔细想了想，我还是去 apt 那边提 patch 让 apt 自己支持 `$releasever` 吧，这样比较彻底 XD