### PR TITLE
docker文档不再使用apt-key及termux软件包地址修改

### DIFF
--- a/help/_posts/1970-01-01-docker-ce.md
+++ b/help/_posts/1970-01-01-docker-ce.md
@@ -11,12 +11,12 @@ category: help
 
 ### Debian/Ubuntu 用户
 
-以下内容根据 [官方文档](https://docs.docker.com/engine/installation/linux/docker-ce/debian/) 修改而来。
+以下内容根据 [官方文档](https://docs.docker.com/engine/install/debian/) 修改而来。
 
 如果你过去安装过 docker，先删掉:
 
 ```bash
-sudo apt-get remove docker docker-engine docker.io
+sudo apt-get remove docker docker-engine docker.io containerd runc
 ```
 
 首先安装依赖:
@@ -40,7 +40,7 @@ sudo apt-get install apt-transport-https ca-certificates curl gnupg2 software-pr
 {% raw %}
 <p></p>
 <pre>
-<code id="deb-gpg-content">curl -fsSL https://download.docker.com/linux/{{ deb_release }}/gpg | sudo apt-key add -</code>
+<code id="deb-gpg-content">curl -fsSL https://download.docker.com/linux/{{ deb_release }}/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg</code>
 </pre>
 {% endraw %}
 
@@ -51,7 +51,7 @@ sudo apt-get install apt-transport-https ca-certificates curl gnupg2 software-pr
 <p></p>
 <pre>
 <code class="language-bash" id="deb-amd64-content">sudo add-apt-repository \
-   "deb [arch=amd64] https://{%endraw%}{{ site.hostname }}{%raw%}/docker-ce/linux/{{deb_release}} \
+   "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://{%endraw%}{{ site.hostname }}{%raw%}/docker-ce/linux/{{deb_release}} \
    $(lsb_release -cs) \
    stable"</code>
 </pre>
@@ -63,7 +63,7 @@ sudo apt-get install apt-transport-https ca-certificates curl gnupg2 software-pr
 {% raw %}
 <p></p>
 <pre>
-<code id="deb-arm-content">echo "deb [arch=armhf] https://{%endraw%}{{ site.hostname }}{%raw%}/docker-ce/linux/{{deb_release}} \
+<code id="deb-arm-content">echo "deb [arch=armhf signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://{%endraw%}{{ site.hostname }}{%raw%}/docker-ce/linux/{{deb_release}} \
      $(lsb_release -cs) stable" | \
     sudo tee /etc/apt/sources.list.d/docker.list</code>
 </pre>
@@ -78,18 +78,18 @@ sudo apt-get install docker-ce
 
 ### Fedora/CentOS/RHEL
 
-以下内容根据 [官方文档](https://docs.docker.com/engine/installation/linux/docker-ce/centos/) 修改而来。
+以下内容根据 [官方文档](https://docs.docker.com/engine/install/centos/) 修改而来。
 
 如果你之前安装过 docker，请先删掉
 
 ```bash
-sudo yum remove docker docker-common docker-selinux docker-engine
+sudo yum remove docker docker-client docker-client-latest docker-common docker-latest docker-latest-logrotate docker-logrotate docker-engine
 ```
 
 安装一些依赖
 
 ```bash
-sudo yum install -y yum-utils device-mapper-persistent-data lvm2 wget
+sudo yum install -y yum-utils device-mapper-persistent-data lvm2
 ```
 
 <form class="form-inline">
@@ -105,7 +105,7 @@ sudo yum install -y yum-utils device-mapper-persistent-data lvm2 wget
 {% raw %}
 <p></p>
 <pre>
-<code id="yum-content">wget -O /etc/yum.repos.d/docker-ce.repo https://download.docker.com/linux/{{ yum_release }}/docker-ce.repo</code>
+<code id="yum-content">yum-config-manager --add-repo https://download.docker.com/linux/{{ yum_release }}/docker-ce.repo</code>
 </pre>
 {% endraw %}
 

--- a/help/_posts/1970-01-01-termux.md
+++ b/help/_posts/1970-01-01-termux.md
@@ -42,22 +42,12 @@ termux-change-repo
 
 ### 命令行替换
 
-如果您在使用termux v0.118及以上版本，使用如下命令行替换官方源为 TUNA 镜像源
+使用如下命令行替换官方源为 TUNA 镜像源
 
 ``` bash
-sed -i 's@^\(deb.*stable main\)$@#\1\ndeb https://{{ site.hostname }}/termux/termux-packages-24 stable main@' $PREFIX/etc/apt/sources.list
+sed -i 's@^\(deb.*stable main\)$@#\1\ndeb https://{{ site.hostname }}/termux/apt/termux-main stable main@' $PREFIX/etc/apt/sources.list
 apt update && apt upgrade
 ```
-
-如果您在使用termux v0.117及以下版本，则需要使用如下命令
-
-```bash
-sed -i 's@^\(deb.*stable main\)$@#\1\ndeb https://mirrors.tuna.tsinghua.edu.cn/termux/termux-packages-24 stable main@' $PREFIX/etc/apt/sources.list
-sed -i 's@^\(deb.*games stable\)$@#\1\ndeb https://mirrors.tuna.tsinghua.edu.cn/termux/game-packages-24 games stable@' $PREFIX/etc/apt/sources.list.d/game.list
-sed -i 's@^\(deb.*science stable\)$@#\1\ndeb https://mirrors.tuna.tsinghua.edu.cn/termux/science-packages-24 science stable@' $PREFIX/etc/apt/sources.list.d/science.list
-apt update && apt upgrade
-```
-
 
 ### 手动修改
 
@@ -65,21 +55,7 @@ apt update && apt upgrade
 
 ```
 # The termux repository mirror from TUNA:
-deb https://{{ site.hostname }}/termux/termux-packages-24 stable main
-```
-
-（仅v0.117及以下）编辑 `$PREFIX/etc/apt/sources.list.d/game.list` 修改为如下内容
-
-```
-# The termux repository mirror from TUNA:
-deb https://{{ site.hostname }}/termux/termux-packages-24 games main
-```
-
-（仅v0.117及以下）编辑 `$PREFIX/etc/apt/sources.list.d/science.list` 修改为如下内容
-
-```
-# The termux repository mirror from TUNA:
-deb https://{{ site.hostname }}/termux/termux-packages-24 science main
+deb https://{{ site.hostname }}/termux/apt/termux-main stable main
 ```
 
 请使用内置或安装在 Termux 里的文本编辑器，例如 `vi` / `vim` / `nano` 等，**不要使用 RE 管理器等其他具有 ROOT 权限的外部 APP** 来修改 Termux 的文件
@@ -88,9 +64,9 @@ deb https://{{ site.hostname }}/termux/termux-packages-24 science main
 
 镜像站还提供了如下社区维护的源，如需使用请自行添加：
 
-- https://{{ site.hostname }}/termux/x11-packages
-- https://{{ site.hostname }}/termux/unstable-packages
-- https://{{ site.hostname }}/termux/termux-root-packages-24
+- https://{{ site.hostname }}/termux/apt/termux-x11
+- https://{{ site.hostname }}/termux/apt/termux-root
+
 
 ### 警告
 


### PR DESCRIPTION
1. 将不再安全的apt-key改为官方文档使用的gpg -dearmor (see https://github.com/tuna/issues/issues/1413)
2. 修改termux软件包地址为/apt/pacname形式