### PR TITLE
修复typo

### DIFF
--- a/help/_posts/1970-01-01-docker-ce.md
+++ b/help/_posts/1970-01-01-docker-ce.md
@@ -40,7 +40,7 @@ sudo apt-get install apt-transport-https ca-certificates curl gnupg2 software-pr
 {% raw %}
 <p></p>
 <pre>
-<code id="deb-gpg-content">curl -fsSL https://download.docker.com/linux/{{ deb_release }}/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg</code>
+<code id="deb-gpg-content">curl -fsSL https://download.docker.com/linux/{{ deb_release }}/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg</code>
 </pre>
 {% endraw %}
 


### PR DESCRIPTION
同步docker-ce官网指引，下载文件和校验签名保持一致