### PR TITLE
修改PyPI帮助文档中PyPI的大小写

### DIFF
--- a/help/_posts/1970-01-01-pypi.md
+++ b/help/_posts/1970-01-01-pypi.md
@@ -4,9 +4,9 @@ layout: help
 mirrorid: pypi
 ---
 
-## pypi 镜像使用帮助
+## PyPI 镜像使用帮助
 
-pypi 镜像在每次同步成功后间隔 5 分钟同步一次。
+PyPI 镜像在每次同步成功后间隔 5 分钟同步一次。
 
 ### 临时使用
 


### PR DESCRIPTION
参考原站的大小写（[https://pypi.org/](https://pypi.org/)），将全小写（`pypi`）改为原站的拼写（`PyPI`）。