### PR TITLE
Update ROS document

### DIFF
--- a/help/_posts/1970-01-01-ros.md
+++ b/help/_posts/1970-01-01-ros.md
@@ -15,9 +15,11 @@ mirrorid: ros
 	<select class="form-control release-select" data-template="#apt-template" data-target="#apt-content">
 		<option data-os="debian" data-release="jessie">Debian 8 (Jessie)</option>
 		<option data-os="debian" data-release="stretch">Debian 9 (Stretch)</option>
+		<option data-os="debian" data-release="buster">Debian 10 (Buster)</option>
 		<option data-os="ubuntu" data-release="trusty">Ubuntu 14.04 LTS</option>
 		<option data-os="ubuntu" data-release="xenial">Ubuntu 16.04 LTS</option>
-		<option data-os="ubuntu" data-release="bionic" selected>Ubuntu 18.04 LTS</option>		
+		<option data-os="ubuntu" data-release="bionic">Ubuntu 18.04 LTS</option>		
+		<option data-os="ubuntu" data-release="focal" selected>Ubuntu 20.04 LTS</option>		
 </select>
 </div>
 </form>


### PR DESCRIPTION
- add ubuntu 20.04 (focal) and debian 10 (buster)