### PR TITLE
genisoinfo: ubuntu and id in python script

### DIFF
--- a/geninfo/genisolist.ini
+++ b/geninfo/genisolist.ini
@@ -66,37 +66,51 @@ platform = $4
 key_by = $2 $4
 sort_by = $4 $2
 
-[ubuntu desktop]
+[ubuntu_desktop]
 distro = Ubuntu
 listvers = 4
-# If one glob is not enough for locating all images, you can use "location_N"
-# to specify more globs. N start from 0 and must a sequence (0,1,2...).
-location_0 = ubuntu-releases/[a-z]*/ubuntu-*-desktop-i386.iso
-location_1 = ubuntu-releases/[a-z]*/ubuntu-*-desktop-amd64.iso
+location = ubuntu-releases/[a-z]*/ubuntu-*-desktop-*.iso
 pattern = ubuntu-([0-9.]+)-desktop-(\w+).iso
 version = $1
 type = Desktop LiveDVD
 platform = $2
 
-[ubuntu live server]
+[ubuntu_preinstalled_desktop]
+distro = Ubuntu
+listvers = 4
+location = ubuntu-cdimage/releases/[a-z]*/release/ubuntu-*-preinstalled-desktop-*.img.xz
+pattern = ubuntu-([0-9.]+)-preinstalled-desktop-(\w+).img.xz
+version = $1
+type = Desktop LiveDVD/.img.xz
+platform = $2
+
+[ubuntu_live_server]
 distro = Ubuntu
 listvers = 4
 # If one glob is not enough for locating all images, you can use "location_N"
 # to specify more globs. N start from 0 and must a sequence (0,1,2...).
-location_0 = ubuntu-releases/[a-z]*/ubuntu-*-live-server-i386.iso
-location_1 = ubuntu-releases/[a-z]*/ubuntu-*-live-server-amd64.iso
+location_0 = ubuntu-releases/[a-z]*/ubuntu-*-live-server-*.iso
+location_1 = ubuntu-cdimage/releases/[a-z]*/release/ubuntu-*-live-server-*.iso
 pattern = ubuntu-([0-9.]+)-live-server-(\w+).iso
 version = $1
 type = Server
 platform = $2
 
-[ubuntu server]
+[ubuntu_preinstalled_server]
 distro = Ubuntu
 listvers = 4
-# If one glob is not enough for locating all images, you can use "location_N"
-# to specify more globs. N start from 0 and must a sequence (0,1,2...).
-location_0 = ubuntu-releases/[a-z]*/ubuntu-*-server-i386.iso
-location_1 = ubuntu-releases/[a-z]*/ubuntu-*-server-amd64.iso
+location = ubuntu-cdimage/releases/[a-z]*/release/ubuntu-*-preinstalled-server-*.img.xz
+pattern = ubuntu-([0-9.]+)-preinstalled-server-(\w+).img.xz
+version = $1
+type = Server/.img.xz
+platform = $2
+
+# If live and preinstalled server match failed, fallback to default server.
+# Currently this rule couldn't match any more file.
+[ubuntu_server]
+distro = Ubuntu
+listvers = 4
+location = ubuntu-releases/[a-z]*/ubuntu-*-server-*.iso
 pattern = ubuntu-([0-9.]+)-server-(\w+).iso
 version = $1
 type = Server
@@ -169,6 +183,15 @@ version = $1
 platform = $2
 listvers = 3
 type = network installer directory
+
+[ubuntu_core]
+distro = Ubuntu Core
+location = ubuntu-cdimage/ubuntu-core/*/stable/current/ubuntu-core-*.img.xz
+pattern = ubuntu-core-([0-9.]+)-(\w+).img.xz
+version = $1
+platform = $2
+listvers = 3
+type = .img.xz
 
 [debian_cd]
 distro = Debian

--- a/geninfo/genisolist.ini
+++ b/geninfo/genisolist.ini
@@ -79,9 +79,9 @@ platform = $2
 distro = Ubuntu
 listvers = 4
 location = ubuntu-cdimage/releases/[a-z]*/release/ubuntu-*-preinstalled-desktop-*.img.xz
-pattern = ubuntu-([0-9.]+)-preinstalled-desktop-(\w+).img.xz
+pattern = ubuntu-([0-9.]+)-preinstalled-desktop-(.+).img.xz
 version = $1
-type = Desktop LiveDVD/.img.xz
+type = Preinstalled Desktop
 platform = $2
 
 [ubuntu_live_server]
@@ -91,7 +91,7 @@ listvers = 4
 # to specify more globs. N start from 0 and must a sequence (0,1,2...).
 location_0 = ubuntu-releases/[a-z]*/ubuntu-*-live-server-*.iso
 location_1 = ubuntu-cdimage/releases/[a-z]*/release/ubuntu-*-live-server-*.iso
-pattern = ubuntu-([0-9.]+)-live-server-(\w+).iso
+pattern = ubuntu-([0-9.]+)-live-server-(.+).iso
 version = $1
 type = Server
 platform = $2
@@ -100,9 +100,9 @@ platform = $2
 distro = Ubuntu
 listvers = 4
 location = ubuntu-cdimage/releases/[a-z]*/release/ubuntu-*-preinstalled-server-*.img.xz
-pattern = ubuntu-([0-9.]+)-preinstalled-server-(\w+).img.xz
+pattern = ubuntu-([0-9.]+)-preinstalled-server-(.+).img.xz
 version = $1
-type = Server/.img.xz
+type = Preinstalled Server
 platform = $2
 
 # If live and preinstalled server match failed, fallback to default server.
@@ -187,7 +187,7 @@ type = network installer directory
 [ubuntu_core]
 distro = Ubuntu Core
 location = ubuntu-cdimage/ubuntu-core/*/stable/current/ubuntu-core-*.img.xz
-pattern = ubuntu-core-([0-9.]+)-(\w+).img.xz
+pattern = ubuntu-core-([0-9]+)-(.+).img.xz
 version = $1
 platform = $2
 listvers = 3

--- a/geninfo/genisolist.py
+++ b/geninfo/genisolist.py
@@ -20,8 +20,16 @@ def getPlatformPriority(platform):
     platform = platform.lower()
     if platform in ['amd64', 'x86_64', '64bit']:
         return 100
+    elif platform in ['arm64', 'aarch64', 'arm64v8']:
+        return 95
+    elif platform in ['riscv64']:
+        return 95
+    elif platform in ['loongson2f', 'loongson3']:
+        return 95
     elif platform in ['i386', 'i486', 'i586', 'i686', 'x86', '32bit']:
         return 90
+    elif platform in ['arm32', 'armhf', 'armv7']:
+        return 85
     else:
         return 0
 


### PR DESCRIPTION
This PR introduce a breaking change in `/genisoinfo`. It's expected to compare generated results from mirror site.