### PR TITLE
Add get.docker.com

### DIFF
--- a/help/_posts/1970-01-01-docker-ce.md
+++ b/help/_posts/1970-01-01-docker-ce.md
@@ -8,6 +8,22 @@ category: help
 
 **注意: 本镜像只提供 Debian/Ubuntu/Fedora/CentOS/RHEL 的 docker 软件包，非 dockerhub**
 
+### 自动安装
+
+Docker 提供了一个自动配置与安装的脚本，支持 Debian、RHEL、SUSE 系列及衍生系统的安装。
+
+以下内容假定
+
+- 您为 root 用户，或有 sudo 权限，或知道 root 密码；
+- 您系统上有 curl 或 wget
+
+```bash
+export DOWNLOAD_URL="https://{{ site.hostname }}/docker-ce"
+# 如您使用 curl
+curl -fsSL https://get.docker.com/ | sh
+# 如您使用 wget
+wget -O- https://get.docker.com/ | sh
+```
 
 ### Debian/Ubuntu 用户
 


### PR DESCRIPTION
Docker provides a convenience script at https://get.docker.com/ to install Docker into development environments non-interactively.

Ref: https://docs.docker.com/engine/install/debian/#install-using-the-convenience-script