### PR TITLE
[pypi] add guidelines for configuring multiple index urls

### DIFF
--- a/help/_posts/1970-01-01-pypi.md
+++ b/help/_posts/1970-01-01-pypi.md
@@ -30,3 +30,15 @@ pip config set global.index-url https://{{ site.pypi }}/simple
 ```
 python -m pip install -i https://{{ site.pypi }}/simple --upgrade pip
 ```
+
+### 配置多个镜像源
+
+如果您想配置多个镜像源平衡负载，可进行如下配置：
+
+```
+pip config set global.extra-index-url "<url1> <url2>..."
+```
+
+请自行替换引号内的内容，源地址之间需要有空格
+
+可用的 `pypi` 源列表（校园网联合镜像站）：https://mirrors.cernet.edu.cn/list/pypi

--- a/help/_posts/1970-01-01-pypi.md
+++ b/help/_posts/1970-01-01-pypi.md
@@ -33,7 +33,7 @@ python -m pip install -i https://{{ site.pypi }}/simple --upgrade pip
 
 ### 配置多个镜像源
 
-如果您想配置多个镜像源平衡负载，可进行如下配置：
+如果您想配置多个镜像源平衡负载，可在已经替换 index-url 的情况下通过以下方式继续增加源站：
 
 ```
 pip config set global.extra-index-url "<url1> <url2>..."

--- a/help/_posts/1970-01-01-pypi.md
+++ b/help/_posts/1970-01-01-pypi.md
@@ -22,13 +22,13 @@ pip install -i https://{{ site.pypi }}/simple some-package
 
 ```
 python -m pip install --upgrade pip
-pip config set global.extra-index-url https://{{ site.pypi }}/simple
+pip config set global.index-url https://{{ site.pypi }}/simple
 ```
 
 如果您到 pip 默认源的网络连接较差，临时使用本镜像站来升级 pip：
 
 ```
-python -m pip install --extra-index-url https://{{ site.pypi }}/simple --upgrade pip
+python -m pip install -i https://{{ site.pypi }}/simple --upgrade pip
 ```
 
 ### 配置多个镜像源


### PR DESCRIPTION
The `--extra-index-url` option allows the user to configure multiple index urls, thus balancing the load.