### PR TITLE
help: elpa: add gnu-devel and nongnu-devel

### DIFF
--- a/help/_posts/1970-01-01-elpa.md
+++ b/help/_posts/1970-01-01-elpa.md
@@ -13,6 +13,8 @@ ELPA 是 Emacs 内建包管理器 `package.el` 的软件源，本镜像支持了
 |-------------------|---------------------------------------------|
 | [GNU ELPA](http://elpa.gnu.org/)          | http://{{ site.hostname }}/elpa/gnu/          |
 | [NonGNU ELPA](http://elpa.nongnu.org/)          | http://{{ site.hostname }}/elpa/nongnu/          |
+| [GNU ELPA Devel](http://elpa.gnu.org/devel/)    | http://{{ site.hostname }}/elpa/gnu-devel/ |
+| [NonGNU ELPA Devel](https://elpa.nongnu.org/nongnu-devel/) | http://{{ site.hostname }}/elpa/nongnu-devel/ |
 | [MELPA](https://melpa.org/)             | http://{{ site.hostname }}/elpa/melpa/        |
 | [MELPA Stable](http://stable.melpa.org/#/)      | http://{{ site.hostname }}/elpa/stable-melpa/ |
 | [Org](http://orgmode.org/elpa.html)               | http://{{ site.hostname }}/elpa/org/          |
@@ -21,8 +23,9 @@ ELPA 是 Emacs 内建包管理器 `package.el` 的软件源，本镜像支持了
 根据你的需求，设置 package-archives ，比如用 GNU ELPA 和 MELPA：
 
 ```lisp
-(setq package-archives '(("gnu"   . "http://{{ site.hostname }}/elpa/gnu/")
-                         ("melpa" . "http://{{ site.hostname }}/elpa/melpa/")))
+(setq package-archives '(("gnu"    . "http://{{ site.hostname }}/elpa/gnu/")
+                         ("nongnu" . "http://{{ site.hostname }}/elpa/nongnu/")
+                         ("melpa"  . "http://{{ site.hostname }}/elpa/melpa/")))
 (package-initialize) ;; You might already have this line
 ```
 
@@ -69,9 +72,12 @@ Cask 用户
 假如不清楚需要用哪些 ELPA 的话
 
 - `gnu` 一般是必备的，其它的 elpa 中的包会依赖 `gnu` 中的包
+- `nongnu` 建议启用，类似于 `melpa` 但是 Emacs 官方维护的
 - `melpa` 滚动升级，收录了的包的数量最大
 - `stable-melpa` 依据源码的 Tag （Git）升级，数量比 `melpa` 少，因为很多包作者根本不打 Tag
 - `org` 仅仅为了 `org-plus-contrib` 这一个包，org 重度用户使用
+- `gnu-devel` 收录 `gnu` 中的包的开发中版本，一般不必启用（与 `gnu` 的关系类似于 `melpa` 与 `stable-melpa` 的关系）
+- `nongnu-devel` 收录 `nongnu` 中的包的开发中版本，一般不必启用
 
 上游
 ====


### PR DESCRIPTION
1. add gnu-devel and nongnu-devel to the table
2. add short descriptions in the section "关于 ELPA 的选择"