### PR TITLE
Update ROS2 doc

### DIFF
--- a/help/_posts/1970-01-01-ros2.md
+++ b/help/_posts/1970-01-01-ros2.md
@@ -10,7 +10,7 @@ mirrorid: ros2
 
 ```bash
 sudo apt install curl gnupg2
-sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
+sudo curl -sSL https://{{ site.hostname }}/rosdistro/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
 ```
 
 
@@ -44,4 +44,4 @@ sudo apt update
 </script>
 {%endraw%}
 
-Reference: https://docs.ros.org/en/foxy/Installation/Ubuntu-Install-Debians.html
+Reference: https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html#setup-sources


### PR DESCRIPTION
- Download ros.key directly from tuna, since it's in the mirrored rosdistro repository.
- Update reference link