### PR TITLE
fix 'jekyll-fontawesome-svg' '~> 0.3.4'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://mirrors.tuna.tsinghua.edu.cn/rubygems/'
 gem 'github-pages'
 gem 'jekyll-babel'
-gem 'jekyll-fontawesome-svg'
+gem 'jekyll-fontawesome-svg' '~> 0.3.4'
 gem 'jekyll-minifier'


### PR DESCRIPTION
Resolve missing "question-circle. svg" source files caused by jekyll-fontawesome-svg upgrading to 0.4.0.