### PR TITLE
homebrew 镜像帮助更新

### DIFF
--- a/help/_posts/1970-01-01-homebrew.md
+++ b/help/_posts/1970-01-01-homebrew.md
@@ -8,9 +8,17 @@ mirrorid: homebrew
 
 **注：该镜像是 Homebrew / Linuxbrew 源程序以及 formula / cask 索引的镜像（即 `brew update` 时所更新内容）。本镜像站同时提供相应的二进制预编译包的镜像，请参考 [Homebrew bottles 镜像使用帮助](https://{{ site.hostname }}/help/homebrew-bottles/)**
 
-本站提供了 <https://github.com/Homebrew> 组织下的以下 `repo`：`brew`, `homebrew-core`, `homebrew-cask`, `homebrew-cask-fonts`, `homebrew-cask-drivers`, `homebrew-cask-versions`, `homebrew-command-not-found`, `homebrew-services`, `install`。
+本站提供了 <https://github.com/Homebrew> 组织下的以下 `repo`：`brew`, `homebrew-core`, `homebrew-cask`, `homebrew-cask-fonts`, `homebrew-cask-versions`, `homebrew-command-not-found`, `homebrew-services`, `install`。
 
-日常使用，可设置如下环境变量使用本站提供的 Homebrew 镜像：
+_注：自brew 3.3.0 (2021 年 10 月 25日) 起，Linuxbrew 核心仓库 `linuxbrew-core` 已被弃用。Linuxbrew 用户应迁移至 `homebrew-core`，并请依本镜像使用帮助重新设置镜像。具体请参阅本帮助 `Linuxbrew 镜像迁移说明` 章节。_
+
+_注：自brew 4.0.0 (2023 年 2 月 16日) 起，`HOMEBREW_INSTALL_FROM_API` 会成为默认行为，无需设置。大部分用户无需再克隆 `homebrew-core` 仓库，故无需设置 `HOMEBREW_CORE_GIT_REMOTE` 环境变量；但若需要运行 `brew` 的开发命令或者 `brew` 安装在非官方支持的默认 prefix 位置，则仍需设置 `HOMEBREW_CORE_GIT_REMOTE` 环境变量。如果不想通过 API 安装，可以设置 `HOMEBREW_NO_INSTALL_FROM_API=1`。_
+
+_注：自brew 4.0.22 (2023 年 6 月 12 日) 起，`homebrew-cask-drivers` 已被弃用，所有 cask 合并至 `homebrew-cask` 仓库。本帮助内已移除克隆 `homebrew-cask-drivers` 仓库的命令。已克隆用户可选择运行 `brew untap homebrew/cask-drivers` 命令移除此仓库。_
+
+### 日常使用
+
+可设置如下环境变量使用本站提供的 Homebrew 镜像：
 
 ```bash
 export HOMEBREW_API_DOMAIN="https://{{ site.hostname }}/homebrew-bottles/api"
@@ -100,7 +108,6 @@ brew tap --custom-remote --force-auto-update homebrew/cask https://{{ site.hostn
 
 # 除 homebrew/core 和 homebrew/cask 仓库外的 tap 仓库仍然需要设置镜像
 brew tap --custom-remote --force-auto-update homebrew/cask-fonts https://{{ site.hostname }}/git/homebrew/homebrew-cask-fonts.git
-brew tap --custom-remote --force-auto-update homebrew/cask-drivers https://{{ site.hostname }}/git/homebrew/homebrew-cask-drivers.git
 brew tap --custom-remote --force-auto-update homebrew/cask-versions https://{{ site.hostname }}/git/homebrew/homebrew-cask-versions.git
 brew tap --custom-remote --force-auto-update homebrew/command-not-found https://{{ site.hostname }}/git/homebrew/homebrew-command-not-found.git
 brew tap --custom-remote --force-auto-update homebrew/services https://{{ site.hostname }}/git/homebrew/homebrew-services.git
@@ -108,7 +115,7 @@ brew update
 
 # 或使用下面的几行命令自动设置
 export HOMEBREW_CORE_GIT_REMOTE="https://{{ site.hostname }}/git/homebrew/homebrew-core.git"
-for tap in core cask{,-fonts,-drivers,-versions} command-not-found services; do
+for tap in core cask{,-fonts,-versions} command-not-found services; do
     brew tap --custom-remote --force-auto-update "homebrew/${tap}" "https://{{ site.hostname }}/git/homebrew/homebrew-${tap}.git"
 done
 brew update
@@ -126,6 +133,7 @@ brew tap --custom-remote --force-auto-update homebrew/core https://{{ site.hostn
 
 # 除 homebrew/core 仓库外的 tap 仓库仍然需要设置镜像
 brew tap --custom-remote --force-auto-update homebrew/command-not-found https://{{ site.hostname }}/git/homebrew/homebrew-command-not-found.git
+brew tap --custom-remote --force-auto-update homebrew/services https://{{ site.hostname }}/git/homebrew/homebrew-services.git
 brew update
 ```
 
@@ -144,7 +152,9 @@ test -r ~/.zprofile && echo 'export HOMEBREW_BREW_GIT_REMOTE="https://{{ site.ho
 test -r ~/.zprofile && echo 'export HOMEBREW_CORE_GIT_REMOTE="https://{{ site.hostname }}/git/homebrew/homebrew-core.git"' >> ~/.zprofile
 ```
 
-_镜像迁移说明：Linuxbrew 核心仓库（`linuxbrew-core`）自 2021 年 10 月 25 日（`brew` 版本 3.3.0 起）被弃用，Linuxbrew 用户应迁移至 `homebrew-core`。Linuxbrew 用户请依新版镜像说明重新设置镜像。注意迁移前请先运行 `brew update` 将 `brew` 更新至 3.3.0 或以上版本。迁移过程中若出现任何问题，可使用如下命令重新安装 `homebrew-core`：_
+### Linuxbrew 镜像迁移说明
+
+Linuxbrew 核心仓库（`linuxbrew-core`）自 2021 年 10 月 25 日（`brew` 版本 3.3.0 起）被弃用，Linuxbrew 用户应迁移至 `homebrew-core`。Linuxbrew 用户请依新版镜像说明重新设置镜像。注意迁移前请先运行 `brew update` 将 `brew` 更新至 3.3.0 或以上版本。迁移过程中若出现任何问题，可使用如下命令重新安装 `homebrew-core`：
 
 ```bash
 export HOMEBREW_CORE_GIT_REMOTE="https://{{ site.hostname }}/git/homebrew/homebrew-core.git"
@@ -156,6 +166,8 @@ brew tap --custom-remote --force-auto-update homebrew/core https://{{ site.hostn
 
 _(感谢 Snowonion Lee 提供说明)_
 
+- 以下针对 macOS 系统上的 Homebrew
+
 ```bash
 # brew 程序本身，Homebrew / Linuxbrew 相同
 unset HOMEBREW_BREW_GIT_REMOTE
@@ -165,17 +177,29 @@ git -C "$(brew --repo)" remote set-url origin https://github.com/Homebrew/brew
 unset HOMEBREW_API_DOMAIN
 unset HOMEBREW_CORE_GIT_REMOTE
 BREW_TAPS="$(BREW_TAPS="$(brew tap 2>/dev/null)"; echo -n "${BREW_TAPS//$'\n'/:}")"
-for tap in core cask{,-fonts,-drivers,-versions} command-not-found services; do
+for tap in core cask{,-fonts,-versions} command-not-found services; do
     if [[ ":${BREW_TAPS}:" == *":homebrew/${tap}:"* ]]; then  # 只复原已安装的 Tap
         brew tap --custom-remote "homebrew/${tap}" "https://github.com/Homebrew/homebrew-${tap}"
     fi
 done
+
+# 重新拉取远程
+brew update
+```
+
+- 以下针对 Linux 系统上的 Linuxbrew
+
+```bash
+# brew 程序本身，Homebrew / Linuxbrew 相同
+unset HOMEBREW_BREW_GIT_REMOTE
+git -C "$(brew --repo)" remote set-url origin https://github.com/Homebrew/brew
 
 # 以下针对 Linux 系统上的 Linuxbrew
 unset HOMEBREW_API_DOMAIN
 unset HOMEBREW_CORE_GIT_REMOTE
 brew tap --custom-remote homebrew/core https://github.com/Homebrew/homebrew-core
 brew tap --custom-remote homebrew/command-not-found https://github.com/Homebrew/homebrew-command-not-found
+brew tap --custom-remote homebrew/services https://github.com/Homebrew/homebrew-services
 
 # 重新拉取远程
 brew update


### PR DESCRIPTION
* brew 4.0.22 移除了对homebrew-cask-drivers仓库的支持，关于仓库的设置命令均会报错，因此移除文档内对此仓库的设置命令。 参考Homebrew/brew#15535
报错内容：
`
Error: homebrew/cask-drivers was deprecated. This tap is now empty and all its contents were either deleted or migrated.
`
* 置顶所有有关brew版本更新引起的镜像变化的注解
* 增加Linuxbrew下homebrew-services仓库的设置命令。经过测试，homebrew-services已在systemd/Linux下可用。
  * 测试环境：Debian 11, Ubuntu 20.04, Ubuntu 22.04, Fedora 37
  * 测试bottle：syncthing，unbound
* 分离<复原仓库上游>章节下Homebrew与Linuxbrew共用的codeblock，以免引起误解