### PR TITLE
help: pypi: update poetry command options

### DIFF
--- a/help/_posts/1970-01-01-pypi.md
+++ b/help/_posts/1970-01-01-pypi.md
@@ -58,11 +58,11 @@ pdm config pypi.url https://{{ site.pypi }}/simple
 通过以下命令设置默认镜像：
 
 ```
-poetry source add --default mirrors https://{{ site.pypi }}/simple/
+poetry source add --priority=default mirrors https://{{ site.pypi }}/simple/
 ```
 
 通过以下命令设置次级镜像：
 
 ```
-poetry source add --secondary mirrors https://{{ site.pypi }}/simple/
+poetry source add --priority=secondary mirrors https://{{ site.pypi }}/simple/
 ```


### PR DESCRIPTION
Ref: https://python-poetry.org/docs/cli#options-13

Options `--default` and `--secondary` have been
> Deprecated in favor of --priority.