### PR TITLE
Replace deprecated gems with plugins

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -48,7 +48,7 @@ kramdown:
 sass:
     sass_dir: static/css
 
-gems:
+plugins:
     - jekyll-babel
     - jekyll-sitemap
     - jekyll/fontawesome/svg


### PR DESCRIPTION
Since [Jekyll 3.5.0](https://github.com/jekyll/jekyll/releases/tag/v3.5.0), plugins have been added to config key as replacement for gems in https://github.com/jekyll/jekyll/pull/5130. This patch resolves a deprecation warning "Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly." when executing `bundle exec jekyll serve`.