### PR TITLE
help: gitlab-ce: add bookworm

### DIFF
--- a/help/_posts/1970-01-01-gitlab-ce.md
+++ b/help/_posts/1970-01-01-gitlab-ce.md
@@ -61,7 +61,8 @@ curl https://packages.gitlab.com/gpg.key 2> /dev/null | {{sudo}}apt-key add - &>
 <div class="form-group">
   <label>发行版：</label>
     <select id="select-1-0" class="form-control content-select" data-target="#content-1">
-      <option data-os_name="debian" data-release_name="bullseye" selected>Debian 11</option>
+      <option data-os_name="debian" data-release_name="bookworm" selected>Debian 12</option>
+      <option data-os_name="debian" data-release_name="bullseye">Debian 11</option>
       <option data-os_name="debian" data-release_name="buster">Debian 10</option>
       <option data-os_name="debian" data-release_name="stretch">Debian 9</option>
       <option data-os_name="debian" data-release_name="jessie">Debian 8</option>


### PR DESCRIPTION
Bookworm has been synchronized. However, help is outdated.