### PR TITLE
Update type of IINA

### DIFF
--- a/geninfo/genisolist.ini
+++ b/geninfo/genisolist.ini
@@ -710,7 +710,7 @@ listvers = 4
 location = iina/IINA*.dmg
 pattern = IINA\.(v[\d\.]+)\.dmg
 platform = macOS
-type = x86_64
+type = universal
 version = $1
 category = app
 


### PR DESCRIPTION
从 [1.2.0](https://github.com/iina/iina/releases/tag/v1.2.0) 开始，IINA 通用打包同时支持 x86_64 和 ARM

如果将来他们分开打包，这里还需要修改