### PR TITLE
修复 bs3-polyfill.scss SHA256校验错误导致的显示异常

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -31,7 +31,7 @@
 <title>{{ page_title }}</title>
 {% unless include.nostyle %}
 {% include vite_script.html %}
-<link rel="stylesheet" href="{% vite_asset_path bs3-polyfill.scss %}" media="screen" integrity="sha256-OnlyforlegacybrowsersAAAAAAAAAAAAAAAAAAAAAA=" />
+<link rel="stylesheet" href="{% vite_asset_path bs3-polyfill.scss %}" media="screen" />
 {% if page.legacy %}
 <style>
 .container {


### PR DESCRIPTION
# 问题
改版后镜像站显示颜色变为深蓝色，能明显感知到显示问题
![image](https://github.com/tuna/mirror-web/assets/36541432/06f8faa1-4ff0-4e41-91df-8598abe20bf2)

查看控制台发现存在错误：
![image](https://github.com/tuna/mirror-web/assets/36541432/772e0589-9568-4fd7-83b3-9faed204be19)
```
mirrors.tuna.tsinghua.edu.cn/:1 
 Failed to find a valid digest in the 'integrity' attribute for resource 'https://mirrors.tuna.tsinghua.edu.cn/assets/bs3-polyfill-D-SBFs68.css' with computed SHA-256 integrity 'P9Uwo4Jep5O8z4BWrm2n6HUmxksUVQ8dRLMNI7jK63k='. The resource has been blocked.
```
相关代码在 commit https://github.com/tuna/mirror-web/commit/19109103be00f0b3d8ec9c5547090c3da574dc3e 引入
https://github.com/tuna/mirror-web/blob/26dfed430fbed2d06dfe7321eca05b621b91d20b/_includes/head.html#L34 

尝试删除 `integrity` 后恢复
![image](https://github.com/tuna/mirror-web/assets/36541432/9c1edb68-46ba-4a87-bc85-d1876f3b5ac5)
