### PR TITLE
Fix #433 and #434

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -31,7 +31,7 @@
 <title>{{ page_title }}</title>
 {% unless include.nostyle %}
 {% include vite_script.html %}
-<link rel="stylesheet" href="{% vite_asset_path bs3-polyfill.scss %}" media="screen" integrity="sha256-OnlyforlegacybrowsersAAAAAAAAAAAAAAAAAAAAAA=" />
+<link rel="stylesheet" href="{% vite_asset_path bs3-polyfill.scss %}" media="screen" />
 {% if page.legacy %}
 <style>
 .container {

--- a/_src/components/IsoModal.vue
+++ b/_src/components/IsoModal.vue
@@ -47,7 +47,7 @@ const switchCategory = (category) => {
 </script>
 
 <template>
-  <div class="modal-dialog modal-lg" role="document">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable" role="document">
     <div class="modal-content">
       <div class="modal-header">
         <button
@@ -58,7 +58,7 @@ const switchCategory = (category) => {
         >
           <span aria-hidden="true">×</span>
         </button>
-        <h4 class="modal-title" id="isoModalLabel">获取安装镜像</h4>
+        <h4 class="modal-title" id="isoModalLabel"><a href="#iso-download">获取安装镜像</a></h4>
         <button
           type="button"
           class="btn-close"

--- a/_src/entrypoints/app.ts
+++ b/_src/entrypoints/app.ts
@@ -2,7 +2,7 @@ import Empty from "../components/Empty.vue";
 import IsoModal from "../components/IsoModal.vue";
 import MainMirrorList from "../components/MainMirrorList.vue";
 
-import { BootStrapModal } from "bootstrap/js/dist/modal";
+import Modal from "bootstrap/js/dist/modal";
 import { createApp } from "vue";
 import "./default";
 import "../styles/main-page.scss";
@@ -14,8 +14,8 @@ const isoModalEl = document.getElementById("isoModal");
 
 createApp(IsoModal, {
   onReady: async function () {
-    if (window.location.hash.match(/#iso-download(\?.*)?/)) {
-      new BootStrapModal(isoModalEl).show();
+    if (window.location.hash === "#iso-download") {
+      new Modal(isoModalEl).show();
     }
   },
 }).mount(isoModalEl);


### PR DESCRIPTION
This PR should fix #433 and #434.

`_includes/head.html`
- removes an invalid integrity

`_src/entrypoints/app.ts`
- fixes the import of BootStrap Modal
- removes an unnessary hash matching

`_src/components/IsoModal.vue`
- makes the Modal scrollable
- adds a link to isoModal's hash 